### PR TITLE
apply-rules on lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/CanalTP/transit_model"
 keywords = ["ntfs", "gtfs", "netex", "navitia", "transit"]
 edition = "2018"
 
+[badges]
+travis-ci = { repository = "CanalTP/transit_model" }
+
 [dependencies]
 chrono = "0.4.0"
 csv = "1.0.0"

--- a/fixtures/apply_rules/input/lines.txt
+++ b/fixtures/apply_rules/input/lines.txt
@@ -1,4 +1,4 @@
-line_id,line_name,network_id,commercial_mode_id
-M1,Metro 1,TGN,Metro
-B42,Bus 42,TGN,Bus
-RERA,RER A,TGN,RER
+line_id,line_name,network_id,commercial_mode_id,line_color
+M1,Metro 1,TGN,Metro,F1CCB4
+B42,Bus 42,TGN,Bus,
+RERA,RER A,TGN,RER,FF0000

--- a/fixtures/apply_rules/input/networks.txt
+++ b/fixtures/apply_rules/input/networks.txt
@@ -1,2 +1,3 @@
 network_id,network_name
 TGN,The Great Network
+AN,Another network

--- a/fixtures/apply_rules/output/geometries.txt
+++ b/fixtures/apply_rules/output/geometries.txt
@@ -7,6 +7,7 @@ route:B42F,POINT(50 50)
 route:B42F:2,POINT(30 30)
 route:B42F:3,POINT(23 23)
 route:B42F:4,POINT(69 69)
+line:M1,"LINESTRING(3 4,10 50,20 25)"
 route:M1B:2,POINT(6 6)
 route:M1B:3,POINT(23 23)
 route:M1F:2,POINT(3 3)

--- a/fixtures/apply_rules/output/lines.txt
+++ b/fixtures/apply_rules/output/lines.txt
@@ -1,0 +1,4 @@
+line_id,line_code,line_name,forward_line_name,forward_direction,backward_line_name,backward_direction,line_color,line_text_color,line_sort_order,network_id,commercial_mode_id,geometry_id,line_opening_time,line_closing_time
+M1,,Metro A,,,,,F1CCB4,,8,AN,Bus,line:M1,,
+B42,1234,Bus 42,,,,,,,,TGN,Bus,,,
+RERA,,RER A,forward_name,forward_direction,backward_line_name,backward_direction,0000FF,CC00FF,,TGN,RER,,,

--- a/fixtures/apply_rules/output/report.json
+++ b/fixtures/apply_rules/output/report.json
@@ -14,6 +14,26 @@
       "message": "object_type=route, object_id=RERAB: unknown property_name unknown_property defined"
     },
     {
+      "category": "ObjectNotFound",
+      "message": "object_type=line, object_id=B42, property_name=commercial_mode_id, property_value=unknown: object not found"
+    },
+    {
+      "category": "OldPropertyValueDoesNotMatch",
+      "message": "object_type=line, object_id=B42, property_name=line_sort_order: property_value should be an integer"
+    },
+    {
+      "category": "ObjectNotFound",
+      "message": "object_type=line, object_id=B42, property_name=network_id, property_value=unknown: object not found"
+    },
+    {
+      "category": "OldPropertyValueDoesNotMatch",
+      "message": "object_type=line, object_id=M1, property_name=line_color: property_old_value does not match the value found in the data"
+    },
+    {
+      "category": "OldPropertyValueDoesNotMatch",
+      "message": "object_type=line, object_id=M1, property_name=line_text_color: property_value is an invalid RGB"
+    },
+    {
       "category": "GeometryNotValid",
       "message": "object_type=route, object_id=B42B: invalid geometry"
     },

--- a/fixtures/apply_rules/output/report.json
+++ b/fixtures/apply_rules/output/report.json
@@ -18,7 +18,7 @@
       "message": "object_type=line, object_id=B42, property_name=commercial_mode_id, property_value=unknown: object not found"
     },
     {
-      "category": "OldPropertyValueDoesNotMatch",
+      "category": "NonConvertibleString",
       "message": "object_type=line, object_id=B42, property_name=line_sort_order: property_value should be an integer"
     },
     {
@@ -30,8 +30,12 @@
       "message": "object_type=line, object_id=M1, property_name=line_color: property_old_value does not match the value found in the data"
     },
     {
-      "category": "OldPropertyValueDoesNotMatch",
+      "category": "NonConvertibleString",
       "message": "object_type=line, object_id=M1, property_name=line_text_color: property_value is an invalid RGB"
+    },
+    {
+      "category": "ObjectNotFound",
+      "message": "object_type=line, object_id=M1, property_name=physical_mode_id, property_old_value=unknown: physical mode not found"
     },
     {
       "category": "GeometryNotValid",

--- a/fixtures/apply_rules/output/trips.txt
+++ b/fixtures/apply_rules/output/trips.txt
@@ -1,0 +1,7 @@
+trip_id,route_id,physical_mode_id,dataset_id,service_id,trip_headsign,block_id,company_id,trip_property_id,geometry_id
+M1F1,M1F,Metro,TGDS,Week,,,TGC,,
+M1B1,M1B,Metro,TGDS,Week,,,TGC,,
+B42F1,B42F,RapidTransit,TGDS,Week,,,TGC,,
+B42B1,B42B,RapidTransit,TGDS,Week,,,TGC,,
+RERAF1,RERAF,Metro,TGDS,Week,,,TGC,,
+RERAB1,RERAB,Metro,TGDS,Week,,,TGC,,

--- a/fixtures/apply_rules/property_rules.txt
+++ b/fixtures/apply_rules/property_rules.txt
@@ -23,3 +23,20 @@ route,B42F:4,route_geometry,pouet,"POINT(50 50)"
 route,B42B,route_geometry,,bad_geometry
 route,RERAF,route_geometry,POINT(40 40),POINT(40 40)
 route,RERAB:2,route_geometry,POINT(69 69),POINT(51 51)
+line,M1,line_name,Metro 1,Metro A
+line,B42,line_code,,1234
+line,RERA,forward_line_name,,forward_name
+line,RERA,backward_line_name,,backward_line_name
+line,RERA,forward_direction,,forward_direction
+line,RERA,backward_direction,,backward_direction
+line,M1,line_geometry,,"LINESTRING(3 4,10 50,20 25)"
+line,M1,line_sort_order,,8
+line,B42,line_sort_order,,not_integer
+line,M1,line_color,,FFFF45
+line,RERA,line_color,FF0000,0000FF
+line,RERA,line_text_color,,CC00FF
+line,M1,line_text_color,,invalid
+line,M1,commercial_mode_id,Metro,Bus
+line,B42,commercial_mode_id,Bus,unknown
+line,M1,network_id,TGN,AN
+line,B42,network_id,TGN,unknown

--- a/fixtures/apply_rules/property_rules.txt
+++ b/fixtures/apply_rules/property_rules.txt
@@ -40,3 +40,6 @@ line,M1,commercial_mode_id,Metro,Bus
 line,B42,commercial_mode_id,Bus,unknown
 line,M1,network_id,TGN,AN
 line,B42,network_id,TGN,unknown
+line,B42,physical_mode_id,Bus,RapidTransit
+line,M1,physical_mode_id,unknown,Metro
+line,RERA,physical_mode_id,*,Metro

--- a/src/bin/apply-rules.rs
+++ b/src/bin/apply-rules.rs
@@ -57,15 +57,14 @@ struct Opt {
 fn run() -> Result<()> {
     info!("Launching apply_rules.");
     let opt = Opt::from_args();
-    let model = transit_model::ntfs::read(opt.input)?;
-    let mut collections = model.into_collections();
-    apply_rules::apply_rules(
-        &mut collections,
+
+    let model = apply_rules::apply_rules(
+        transit_model::ntfs::read(opt.input)?,
         opt.complementary_code_rules_files,
         opt.property_rules_files,
         opt.report,
     )?;
-    let model = transit_model::Model::new(collections)?;
+
     transit_model::ntfs::write(&model, opt.output, opt.current_datetime)?;
 
     Ok(())

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -470,8 +470,7 @@ impl ::serde::Serialize for Rgb {
     where
         S: ::serde::Serializer,
     {
-        let color = format!("{:02X}{:02X}{:02X}", self.red, self.green, self.blue);
-        serializer.serialize_str(&color)
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -310,6 +310,7 @@ pub enum ReportType {
     MultipleValue,
     OldPropertyValueDoesNotMatch,
     GeometryNotValid,
+    NonConvertibleString,
 }
 
 #[derive(Debug, Serialize)]

--- a/tests/apply_rules.rs
+++ b/tests/apply_rules.rs
@@ -28,16 +28,13 @@ fn test_apply_complementary_codes() {
         let p_rules = vec![Path::new("./fixtures/apply_rules/property_rules.txt").to_path_buf()];
         let report_path = path.join("report.json");
 
-        let model = transit_model::ntfs::read(input_dir).unwrap();
-        let mut collections = model.into_collections();
-        apply_rules::apply_rules(
-            &mut collections,
+        let model = apply_rules::apply_rules(
+            transit_model::ntfs::read(input_dir).unwrap(),
             cc_rules,
             p_rules,
             Path::new(&report_path).to_path_buf(),
         )
         .unwrap();
-        let model = transit_model::Model::new(collections).unwrap();
         transit_model::ntfs::write(&model, path, get_test_datetime()).unwrap();
         compare_output_dir_with_expected(
             &path,
@@ -46,6 +43,7 @@ fn test_apply_complementary_codes() {
                 "geometries.txt",
                 "lines.txt",
                 "routes.txt",
+                "trips.txt",
                 "report.json",
             ]),
             "./fixtures/apply_rules/output",

--- a/tests/apply_rules.rs
+++ b/tests/apply_rules.rs
@@ -44,6 +44,7 @@ fn test_apply_complementary_codes() {
             Some(vec![
                 "object_codes.txt",
                 "geometries.txt",
+                "lines.txt",
                 "routes.txt",
                 "report.json",
             ]),


### PR DESCRIPTION
add the possibility to change some properties on NTFS lines
- line_name
- line_code
- line_color
- line_text_color
- forward_line_name
- backward_line_name
- forward_direction
- backward_direction
- line_sort_order
- physical_mode_id
- commercial_mode_id
- network_id
- line_geometry