### PR TITLE
fix model-builder doc test in beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
     script: cargo fmt --all -- --check
   allow_failures:
   - rust: nightly
+script:
+- cargo test --verbose
+- cd model-builder && cargo test --verbose
 deploy:
   provider: cargo
   on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ num-traits = "0.2.6"
 path = "transit_model_procmacro"
 version = "0.1.0"
 
-[workspace]
-members = ["model-builder"]
+[dev-dependencies]
+transit_model_builder= "0.1.0"


### PR DESCRIPTION
fix `use of undeclared type or module `transit_model_builder` in rust beta

needed to make test passed