### PR TITLE
Improve test utils reporting for file to file comparison

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -54,7 +54,19 @@ pub fn compare_output_dir_with_expected<P: AsRef<Path>>(
         let expected_file_path = format!("{}/{}", work_dir_expected, filename);
         let expected_contents = get_file_content(expected_file_path);
 
-        assert_eq!(output_contents, expected_contents);
+        let output_lines: Vec<_> = output_contents.split("\n").collect();
+        let expected_lines: Vec<_> = expected_contents.split("\n").collect();
+        assert_eq!(
+            output_lines.len(),
+            expected_lines.len(),
+            "File '{}' contains '{}' lines but the expected result file contains '{}' lines",
+            filename,
+            output_lines.len(),
+            expected_lines.len()
+        );
+        for i in 0..output_lines.len() {
+            assert_eq!(output_lines[i], expected_lines[i]);
+        }
     }
 }
 


### PR DESCRIPTION
A proposition to improve the reporting of file-to-file comparison in the test utils. Today, even after using `pretty_assertions` for text coloration, a failing test is reported like this.

![image](https://user-images.githubusercontent.com/2520723/59666019-4d633980-91b4-11e9-9c6f-3aae7faf956e.png)

This PR is proposing to do an assertion line by line to show a clearer diff. Something like

![image](https://user-images.githubusercontent.com/2520723/59666087-74ba0680-91b4-11e9-977c-d3a2f5a48bc5.png)

Note: There is one drawback though and I'm open to discussion and/or solution: it's going to report only the first assertion error, not all of them.
