### PR TITLE
Fix output fixtures

### DIFF
--- a/fixtures/apply_rules/output_report/report_apply_complementary_codes.json
+++ b/fixtures/apply_rules/output_report/report_apply_complementary_codes.json
@@ -3,7 +3,7 @@
   "warnings": [
     {
       "category": "InvalidFile",
-      "message": "Error reading \"complementary_codes_rules.txt\": CSV deserialize error: unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
+      "message": "Error reading \"complementary_codes_rules.txt\": CSV deserialize error: record 8 (line: 9, byte: 278): unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
     }
   ]
 }

--- a/fixtures/apply_rules/output_report/report_apply_property.json
+++ b/fixtures/apply_rules/output_report/report_apply_property.json
@@ -3,7 +3,7 @@
   "warnings": [
     {
       "category": "InvalidFile",
-      "message": "Error reading \"complementary_codes_rules.txt\": CSV deserialize error: unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
+      "message": "Error reading \"complementary_codes_rules.txt\": CSV deserialize error: record 8 (line: 9, byte: 278): unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
     },
     {
       "category": "MultipleValue",

--- a/fixtures/apply_rules/output_report/report_consolidation_with_object_code.json
+++ b/fixtures/apply_rules/output_report/report_consolidation_with_object_code.json
@@ -3,7 +3,7 @@
   "warnings": [
     {
       "category": "InvalidFile",
-      "message": "Error reading \"complementary_codes_rules.txt\": CSV deserialize error: unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
+      "message": "Error reading \"complementary_codes_rules.txt\": CSV deserialize error: record 8 (line: 9, byte: 278): unknown variant `object_not_allowed`, expected one of `line`, `route`, `stop_point`, `stop_area`"
     },
     {
       "category": "MultipleValue",


### PR DESCRIPTION
csv's error messages changed with version 1.1.0 but I don't know why

`record 8 (line: 9, byte: 278)` (see diff) was already there in the error msg

https://github.com/BurntSushi/rust-csv/compare/1.0.0...1.1.0#diff-9a269209bed069ffb36d5565a91c9840R204