### PR TITLE
Add WGS84 trait for objects that can expose WGS84 coordinates

### DIFF
--- a/src/kv1/read.rs
+++ b/src/kv1/read.rs
@@ -20,13 +20,13 @@ use crate::{
     model::Collections,
     objects::*,
     read_utils::FileHandler,
-    Result,
+    Result, WGS84Coordinates,
 };
 use chrono::NaiveDate;
 use csv;
 use failure::{bail, format_err, ResultExt};
 use geo::algorithm::centroid::Centroid;
-use geo_types::MultiPoint as GeoMultiPoint;
+use geo_types::{MultiPoint as GeoMultiPoint, Point as GeoPoint};
 use lazy_static::lazy_static;
 use log::info;
 use proj::Proj;
@@ -179,6 +179,24 @@ struct Point {
     category: String,
 }
 
+const EPSG_28992: &str = "EPSG:28992";
+// FIXME: String 'EPSG:4326' is failing at runtime (string below is equivalent but works)
+const EPSG_4326: &str = "+proj=longlat +datum=WGS84 +no_defs"; // See https://epsg.io/4326
+#[cfg(feature = "proj")]
+impl WGS84Coordinates for Point {
+    fn coord(&self) -> Result<Coord> {
+        let epsg_28992_point = GeoPoint::new(self.lon, self.lat);
+        let converter = Proj::new_known_crs(&EPSG_28992, &EPSG_4326, None).ok_or_else(|| {
+            format_err!(
+                "Proj cannot build a converter from '{}' to '{}'",
+                EPSG_28992,
+                EPSG_4326
+            )
+        })?;
+        converter.convert(epsg_28992_point).map(Coord::from)
+    }
+}
+
 #[derive(Deserialize, Debug)]
 struct UsrStopArea {
     #[serde(rename = "[UserStopAreaCode]")]
@@ -299,22 +317,11 @@ where
         .from_reader(file_reader);
 
     let mut point_map = BTreeMap::new();
-    let from = "EPSG:28992";
-    // FIXME: String 'EPSG:4326' is failing at runtime (string below is equivalent but works)
-    let to = "+proj=longlat +datum=WGS84 +no_defs"; // See https://epsg.io/4326
-    let proj = match Proj::new_known_crs(&from, &to, None) {
-        Some(p) => p,
-        None => bail!("Proj cannot build a converter from {} to {}", from, to),
-    };
     for point in rdr.deserialize() {
         let point: Point = point.with_context(ctx_from_path!(path))?;
         if point.category == "SP" {
-            let coords = proj.convert((point.lon, point.lat).into())?;
-            let coords = Coord {
-                lon: coords.x(),
-                lat: coords.y(),
-            };
-            point_map.insert(point.code, coords);
+            let wgs84_coords = point.coord()?;
+            point_map.insert(point.code, wgs84_coords);
         }
     }
     Ok(point_map)
@@ -908,7 +915,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{CollectionWithId, Collections, Kv1Line};
+    use super::*;
     use crate::read_utils::PathFileHandler;
     use crate::test_utils::*;
 
@@ -998,5 +1005,28 @@ mod tests {
 
         let mut collections = Collections::default();
         super::make_physical_and_commercial_modes(&mut collections, &kv1_lines).unwrap();
+    }
+
+    mod point {
+        use super::*;
+        use approx::assert_relative_eq;
+
+        // This test uses the Bristol Bus Station coordinates
+        // in EPSG:28992 format (Easting, Northing)
+        // https://epsg.io/map#srs=28992&x=211077&y=522887&z=20
+        // and in the corresponding EPSG:4326 format (aka WGS84)
+        // https://epsg.io/map#srs=4326&x=6.216616&y=52.690512&z=20
+        #[test]
+        fn convert_wgs84() {
+            let point = Point {
+                code: String::from("16000260"),
+                lon: 211077f64,
+                lat: 522887f64,
+                category: String::from("SP"),
+            };
+            let wgs84 = point.coord().unwrap();
+            assert_relative_eq!(wgs84.lon, 6.2166158860471405);
+            assert_relative_eq!(wgs84.lat, 52.69051160106322);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod relations;
 pub mod test_utils;
 pub mod transfers;
 pub mod vptranslator;
+mod wgs84;
+pub use wgs84::WGS84Coordinates;
 
 /// Current version of the NTFS format
 pub const NTFS_VERSION: &str = "0.9";

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -24,7 +24,7 @@ use crate::utils::*;
 use chrono;
 use chrono::NaiveDate;
 use derivative::Derivative;
-use geo_types::Geometry as GeoGeometry;
+use geo_types::{Geometry as GeoGeometry, Point as GeoPoint};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -850,6 +850,7 @@ impl GetObjectType for StopTime {
     }
 }
 
+/// Spatial Coordinates in WGS84 format (aka EPSG:4326)
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Default)]
 pub struct Coord {
     pub lon: f64,
@@ -895,6 +896,15 @@ impl Coord {
             cos_lat: lat_rad.cos(),
             lon_rad: self.lon.to_radians(),
             lat_rad,
+        }
+    }
+}
+
+impl From<GeoPoint<f64>> for Coord {
+    fn from(point: GeoPoint<f64>) -> Self {
+        Coord {
+            lon: point.x(),
+            lat: point.y(),
         }
     }
 }

--- a/src/wgs84.rs
+++ b/src/wgs84.rs
@@ -1,0 +1,24 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+use crate::{objects::Coord, Result};
+
+/// Interface dealing with spatial coordinates in EPSG:4326 format aka WGS84
+/// See https://epsg.io/4326
+pub trait WGS84Coordinates {
+    /// Returns a WGS84 spatial coordinates
+    fn coord(&self) -> Result<Coord>;
+}


### PR DESCRIPTION
This trait will be used in the coming implementation of NaPTAN parsing too so it's not a one-shot trait.