### PR TITLE
Create Stop Areas for Stop Points missing one

### DIFF
--- a/src/transxchange/naptan.rs
+++ b/src/transxchange/naptan.rs
@@ -188,6 +188,7 @@ where
                 stop_areas.push(StopArea {
                     id: id.clone(),
                     name: stop.name.clone(),
+                    visible: true,
                     coord,
                     ..Default::default()
                 })?;

--- a/src/transxchange/naptan.rs
+++ b/src/transxchange/naptan.rs
@@ -185,6 +185,10 @@ where
                 // If the stop point don't have a corresponding stop area
                 // create the stop area based on stop point information
                 let id = format!("Navitia:{}", stop.atco_code);
+                info!(
+                    "Creating StopArea {} for corresponding StopPoint {}",
+                    id, stop.atco_code
+                );
                 stop_areas.push(StopArea {
                     id: id.clone(),
                     name: stop.name.clone(),


### PR DESCRIPTION
Whenever a Stop Point is parsed from NaPTAN dataset which doesn't have a corresponding Stop Area (through `StopsInArea.csv`), we need to create a Stop Area (needed for NTFS) based on the Stop Point information (derived ID, name and coordinates).