### PR TITLE
Support for multiple networks and companies

### DIFF
--- a/fixtures/transxchange2ntfs/input/transxchange/simple.xml
+++ b/fixtures/transxchange2ntfs/input/transxchange/simple.xml
@@ -13,6 +13,10 @@
       <OperatorCode>SSWL</OperatorCode>
       <OperatorShortName>Stagecoach South Wales</OperatorShortName>
     </Operator>
+    <Operator id="O2">
+      <OperatorCode>ANSL</OperatorCode>
+      <OperatorShortName>Phil Anslow</OperatorShortName>
+    </Operator>
   </Operators>
   <Services>
     <Service>

--- a/fixtures/transxchange2ntfs/output/ntfs/companies.txt
+++ b/fixtures/transxchange2ntfs/output/ntfs/companies.txt
@@ -1,2 +1,3 @@
 company_id,company_name,company_address,company_url,company_mail,company_phone
 prefix:SSWL,Stagecoach South Wales,,,,
+prefix:ANSL,Phil Anslow,,,,


### PR DESCRIPTION
This will get the operator reference from `<Service>` in order to generate the Network.

For companies, all `Operator` will generate a new company.