### PR TITLE
Make 'read_config' return unique contributor/dataset

### DIFF
--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -246,11 +246,11 @@ where
 
     manage_calendars(file_handler, &mut collections)?;
 
-    let (contributors, mut datasets, feed_infos) = read_utils::read_config(config_path)?;
-    read_utils::set_dataset_validity_period(&mut datasets, &collections.calendars)?;
+    let (contributor, mut dataset, feed_infos) = read_utils::read_config(config_path)?;
+    read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
-    collections.contributors = contributors;
-    collections.datasets = datasets;
+    collections.contributors = CollectionWithId::new(vec![contributor])?;
+    collections.datasets = CollectionWithId::new(vec![dataset])?;
     collections.feed_infos = feed_infos;
 
     let (networks, companies) = read::read_agency(file_handler)?;

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -1272,9 +1272,9 @@ mod tests {
             create_file_with_content(path, "routes.txt", routes_content);
             create_file_with_content(path, "trips.txt", trips_content);
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(4, collections.lines.len());
             assert_eq!(
@@ -1341,9 +1341,9 @@ mod tests {
             let mut collections = Collections::default();
             let (networks, _) = super::read_agency(&mut handler).unwrap();
             collections.networks = networks;
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(3, collections.lines.len());
 
@@ -1384,9 +1384,9 @@ mod tests {
             let mut collections = Collections::default();
             let (networks, _) = super::read_agency(&mut handler).unwrap();
             collections.networks = networks;
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(3, collections.lines.len());
             assert_eq!(
@@ -1456,9 +1456,9 @@ mod tests {
             let mut collections = Collections::default();
             let (networks, _) = super::read_agency(&mut handler).unwrap();
             collections.networks = networks;
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
         });
     }
@@ -1487,9 +1487,9 @@ mod tests {
             create_file_with_content(path, "trips.txt", trips_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
         });
     }
@@ -1522,9 +1522,9 @@ mod tests {
             let mut collections = Collections::default();
             let (networks, _) = super::read_agency(&mut handler).unwrap();
             collections.networks = networks;
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
 
             assert_eq!(3, collections.lines.len());
@@ -1565,9 +1565,9 @@ mod tests {
             create_file_with_content(path, "routes.txt", routes_content);
             create_file_with_content(path, "trips.txt", trips_content);
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
 
             assert_eq!(2, collections.lines.len());
@@ -1598,9 +1598,9 @@ mod tests {
             create_file_with_content(path, "routes.txt", routes_content);
             create_file_with_content(path, "trips.txt", trips_content);
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
 
             assert_eq!(2, collections.lines.len());
@@ -1632,9 +1632,9 @@ mod tests {
             create_file_with_content(path, "trips.txt", trips_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(1, collections.lines.len());
             assert_eq!(1, collections.routes.len());
@@ -1689,9 +1689,9 @@ mod tests {
 
             let mut comments: CollectionWithId<Comment> = CollectionWithId::default();
             let mut equipments = EquipmentList::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
             let (stop_areas, stop_points) =
                 super::read_stops(&mut handler, &mut comments, &mut equipments).unwrap();
             collections.equipments = CollectionWithId::new(equipments.into_equipments()).unwrap();
@@ -1869,9 +1869,9 @@ mod tests {
             create_file_with_content(path, "trips.txt", trips_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(3, collections.lines.len());
@@ -1910,9 +1910,9 @@ mod tests {
             let mut collections = Collections::default();
             let (networks, _) = super::read_agency(&mut handler).unwrap();
             collections.networks = networks;
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(3, collections.lines.len());
@@ -1943,9 +1943,9 @@ mod tests {
             create_file_with_content(path, "trips.txt", trips_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(3, collections.lines.len());
@@ -1977,9 +1977,9 @@ mod tests {
             create_file_with_content(path, "trips.txt", trips_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             super::read_routes(&mut handler, &mut collections).unwrap();
             assert_eq!(2, collections.vehicle_journeys.len());
@@ -2156,9 +2156,9 @@ mod tests {
             create_file_with_content(path, "stops.txt", stops_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             let mut comments: CollectionWithId<Comment> = CollectionWithId::default();
             let mut equipments = EquipmentList::default();
@@ -2239,9 +2239,9 @@ mod tests {
             create_file_with_content(path, "stops.txt", stops_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             let mut comments: CollectionWithId<Comment> = CollectionWithId::default();
             let mut equipments = EquipmentList::default();
@@ -2503,14 +2503,14 @@ mod tests {
             create_file_with_content(path, "calendar_dates.txt", calendar_dates_content);
 
             let mut collections = Collections::default();
-            let (_, mut datasets, _) = read_utils::read_config(None::<&str>).unwrap();
+            let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
             common_format::manage_calendars(&mut handler, &mut collections).unwrap();
-            read_utils::set_dataset_validity_period(&mut datasets, &collections.calendars).unwrap();
+            read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars).unwrap();
 
             assert_eq!(
-                datasets.into_vec(),
-                vec![Dataset {
+                dataset,
+                Dataset {
                     id: "default_dataset".to_string(),
                     contributor_id: "default_contributor".to_string(),
                     start_date: chrono::NaiveDate::from_ymd(2018, 5, 1),
@@ -2519,7 +2519,7 @@ mod tests {
                     extrapolation: false,
                     desc: None,
                     system: None,
-                }]
+                }
             );
         });
     }
@@ -2534,14 +2534,14 @@ mod tests {
             create_file_with_content(path, "calendar.txt", calendars_content);
 
             let mut collections = Collections::default();
-            let (_, mut datasets, _) = read_utils::read_config(None::<&str>).unwrap();
+            let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
             common_format::manage_calendars(&mut handler, &mut collections).unwrap();
-            read_utils::set_dataset_validity_period(&mut datasets, &collections.calendars).unwrap();
+            read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars).unwrap();
 
             assert_eq!(
-                datasets.into_vec(),
-                vec![Dataset {
+                dataset,
+                Dataset {
                     id: "default_dataset".to_string(),
                     contributor_id: "default_contributor".to_string(),
                     start_date: chrono::NaiveDate::from_ymd(2018, 5, 1),
@@ -2550,7 +2550,7 @@ mod tests {
                     extrapolation: false,
                     desc: None,
                     system: None,
-                }]
+                }
             );
         });
     }
@@ -2623,9 +2623,9 @@ mod tests {
             create_file_with_content(path, "trips.txt", trips_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             super::read_routes(&mut handler, &mut collections).unwrap();
             // physical mode file should contain only three modes
@@ -2729,9 +2729,9 @@ mod tests {
             create_file_with_content(path, "stops.txt", stops_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             let mut comments: CollectionWithId<Comment> = CollectionWithId::default();
             let mut equipments = EquipmentList::default();
@@ -2801,9 +2801,9 @@ mod tests {
             create_file_with_content(path, "stops.txt", stops_content);
 
             let mut collections = Collections::default();
-            let (contributors, datasets, _) = read_utils::read_config(None::<&str>).unwrap();
-            collections.contributors = contributors;
-            collections.datasets = datasets;
+            let (contributor, dataset, _) = read_utils::read_config(None::<&str>).unwrap();
+            collections.contributors = CollectionWithId::new(vec![contributor]).unwrap();
+            collections.datasets = CollectionWithId::new(vec![dataset]).unwrap();
 
             let mut comments: CollectionWithId<Comment> = CollectionWithId::default();
             let mut equipments = EquipmentList::default();

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -19,6 +19,7 @@
 mod read;
 
 use crate::{
+    collection::CollectionWithId,
     model::{Collections, Model},
     read_utils, AddPrefix, Result,
 };
@@ -37,11 +38,11 @@ where
 
     read::read_operday(file_handler, &mut collections)?;
 
-    let (contributors, mut datasets, feed_infos) = read_utils::read_config(config_path)?;
-    read_utils::set_dataset_validity_period(&mut datasets, &collections.calendars)?;
+    let (contributor, mut dataset, feed_infos) = read_utils::read_config(config_path)?;
+    read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
-    collections.contributors = contributors;
-    collections.datasets = datasets;
+    collections.contributors = CollectionWithId::new(vec![contributor])?;
+    collections.datasets = CollectionWithId::new(vec![dataset])?;
     collections.feed_infos = feed_infos;
 
     read::read_usrstop_point(file_handler, &mut collections)?;

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -45,8 +45,8 @@ struct Config {
 pub fn read_config<P: AsRef<path::Path>>(
     config_path: Option<P>,
 ) -> Result<(
-    CollectionWithId<objects::Contributor>,
-    CollectionWithId<objects::Dataset>,
+    objects::Contributor,
+    objects::Dataset,
     BTreeMap<String, String>,
 )> {
     let contributor;
@@ -69,9 +69,7 @@ pub fn read_config<P: AsRef<path::Path>>(
         dataset = objects::Dataset::default();
     }
 
-    let contributors = CollectionWithId::new(vec![contributor])?;
-    let datasets = CollectionWithId::new(vec![dataset])?;
-    Ok((contributors, datasets, feed_infos))
+    Ok((contributor, dataset, feed_infos))
 }
 
 pub fn get_validity_period(
@@ -92,19 +90,14 @@ pub fn get_validity_period(
 }
 
 pub fn set_dataset_validity_period(
-    datasets: &mut CollectionWithId<objects::Dataset>,
+    dataset: &mut objects::Dataset,
     calendars: &CollectionWithId<objects::Calendar>,
 ) -> Result<()> {
     let validity_period = get_validity_period(calendars);
 
     if let Some(vp) = validity_period {
-        let mut objects = datasets.take();
-        for d in &mut objects {
-            d.start_date = vp.start_date;
-            d.end_date = vp.end_date;
-        }
-
-        *datasets = CollectionWithId::new(objects)?;
+        dataset.start_date = vp.start_date;
+        dataset.end_date = vp.end_date;
     }
 
     Ok(())

--- a/src/transxchange/read.rs
+++ b/src/transxchange/read.rs
@@ -235,21 +235,16 @@ pub fn read<P>(
 where
     P: AsRef<Path>,
 {
-    fn init_dataset_validity_periods(
-        mut datasets: CollectionWithId<Dataset>,
-    ) -> Result<CollectionWithId<Dataset>> {
-        let mut datasets = datasets.take();
-        for dataset in &mut datasets {
-            dataset.start_date = MAX_DATE;
-            dataset.end_date = MIN_DATE;
-        }
-        CollectionWithId::new(datasets)
+    fn init_dataset_validity_period(dataset: &mut Dataset) {
+        dataset.start_date = MAX_DATE;
+        dataset.end_date = MIN_DATE;
     }
 
     let mut collections = Collections::default();
-    let (contributors, datasets, feed_infos) = crate::read_utils::read_config(config_path)?;
-    collections.contributors = contributors;
-    collections.datasets = init_dataset_validity_periods(datasets)?;
+    let (contributor, mut dataset, feed_infos) = crate::read_utils::read_config(config_path)?;
+    collections.contributors = CollectionWithId::new(vec![contributor])?;
+    init_dataset_validity_period(&mut dataset);
+    collections.datasets = CollectionWithId::new(vec![dataset])?;
     collections.feed_infos = feed_infos;
     if naptan_path.as_ref().is_file() {
         naptan::read_from_zip(naptan_path, &mut collections)?;


### PR DESCRIPTION
[`read_config`](https://github.com/CanalTP/transit_model/compare/master...woshilapin:read_config?expand=1#diff-a5ae51324be0fd74d0e1e9788b025f85R45) function is not designed to create multiple Contributors or Datasets from a `config.json` but only one of each. So there is no reason the signature of this function returns `CollectionWithId`.

NB: This modification will be useful in the TransXChange convertor implementation.