### PR TITLE
removed read_url utility and reqwest crate 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ num-traits = "0.2.6"
 pretty_assertions = "0.6.1"
 proj = { version = "0.9.3", optional = true }
 regex = "1.1.2"
-reqwest = "0.9"
 rust_decimal = "1.0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -52,4 +51,3 @@ required-features = ["proj"]
 [dev-dependencies]
 approx = "0.3.2"
 rust_decimal_macros = "1.0.1"
-transit_model_builder = { path = "./model-builder" }

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -321,25 +321,6 @@ pub fn read_from_zip<P: AsRef<Path>>(
     read(&mut file_handle, config_path, prefix)
 }
 
-/// Imports a `Model` from a url hosting a zip file containing the [GTFS](http://gtfs.org/).
-///
-/// The `config_path` argument allows you to give a path to a file
-/// containing a json representing the contributor and dataset used
-/// for this GTFS. If not given, default values will be created.
-///
-/// The `prefix` argument is a string that will be prepended to every
-/// identifiers, allowing to namespace the dataset. By default, no
-/// prefix will be added to the identifiers.
-pub fn read_from_url<P: AsRef<Path>>(
-    url: &str,
-    config_path: Option<P>,
-    prefix: Option<String>,
-) -> Result<Model> {
-    let reader = read_utils::read_url(&url)?;
-    let mut file_handle = read_utils::ZipHandler::new(reader, &url)?;
-    read(&mut file_handle, config_path, prefix)
-}
-
 #[derive(PartialOrd, Ord, Debug, Clone, Eq, PartialEq, Hash)]
 enum RouteType {
     Tramway,

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -93,22 +93,3 @@ pub fn read_from_zip<P: AsRef<Path>>(
     let mut file_handle = read_utils::ZipHandler::new(reader, p)?;
     read(&mut file_handle, config_path, prefix)
 }
-
-/// Imports a `Model` from a url hosting a zip file containing the KV1.
-///
-/// The `config_path` argument allows you to give a path to a file
-/// containing a json representing the contributor and dataset used
-/// for this KV1. If not given, default values will be created.
-///
-/// The `prefix` argument is a string that will be prepended to every
-/// identifiers, allowing to namespace the dataset. By default, no
-/// prefix will be added to the identifiers.
-pub fn read_from_url<P: AsRef<Path>>(
-    url: &str,
-    config_path: Option<P>,
-    prefix: Option<String>,
-) -> Result<Model> {
-    let reader = read_utils::read_url(&url)?;
-    let mut file_handle = read_utils::ZipHandler::new(reader, &url)?;
-    read(&mut file_handle, config_path, prefix)
-}

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -25,7 +25,6 @@ use serde::Deserialize;
 use serde_json;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
-use std::io::Read;
 use std::path;
 use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
@@ -218,12 +217,4 @@ where
 {
     let vec = read_objects(file_handler, file_name)?;
     CollectionWithId::new(vec)
-}
-
-/// Read an URL and get a cursor on the hosted file
-pub fn read_url(url: &str) -> Result<std::io::Cursor<Vec<u8>>> {
-    let mut res = reqwest::get(url)?;
-    let mut body = Vec::new();
-    res.read_to_end(&mut body)?;
-    Ok(std::io::Cursor::new(body))
 }


### PR DESCRIPTION
we think that requesting an url to get an archive can be done out of `transit_model`.
`read_url` uses `reqwest` that includes a lot of dependencies. Removing `reqwest` could lighten the build.

@antoine-de, @Tristramg do you use `read_url`?


reqwest dependencies 
```
├── reqwest v0.9.20
│   ├── base64 v0.10.1
│   │   └── byteorder v1.3.2 (*)
│   ├── bytes v0.4.12
│   │   ├── byteorder v1.3.2 (*)
│   │   ├── either v1.5.2
│   │   └── iovec v0.1.2
│   │       └── libc v0.2.60 (*)
│   ├── cookie v0.12.0
│   │   ├── time v0.1.42 (*)
│   │   └── url v1.7.2
│   │       ├── idna v0.1.5
│   │       │   ├── matches v0.1.8
│   │       │   ├── unicode-bidi v0.3.4
│   │       │   │   └── matches v0.1.8 (*)
│   │       │   └── unicode-normalization v0.1.8
│   │       │       └── smallvec v0.6.10
│   │       ├── matches v0.1.8 (*)
│   │       └── percent-encoding v1.0.1
│   ├── cookie_store v0.7.0
│   │   ├── cookie v0.12.0 (*)
│   │   ├── failure v0.1.5 (*)
│   │   ├── idna v0.1.5 (*)
│   │   ├── log v0.4.8 (*)
│   │   ├── publicsuffix v1.5.2
│   │   │   ├── error-chain v0.12.1
│   │   │   │   └── backtrace v0.3.34 (*)
│   │   │   │   [build-dependencies]
│   │   │   │   └── version_check v0.1.5
│   │   │   ├── idna v0.1.5 (*)
│   │   │   ├── lazy_static v1.4.0 (*)
│   │   │   ├── regex v1.2.1 (*)
│   │   │   └── url v1.7.2 (*)
│   │   ├── serde v1.0.99 (*)
│   │   ├── serde_json v1.0.40
│   │   │   ├── itoa v0.4.4 (*)
│   │   │   ├── ryu v1.0.0 (*)
│   │   │   └── serde v1.0.99 (*)
│   │   ├── time v0.1.42 (*)
│   │   ├── try_from v0.3.2
│   │   │   └── cfg-if v0.1.9 (*)
│   │   └── url v1.7.2 (*)
│   ├── encoding_rs v0.8.17 (*)
│   ├── flate2 v1.0.9
│   │   ├── crc32fast v1.2.0
│   │   │   └── cfg-if v0.1.9 (*)
│   │   ├── libc v0.2.60 (*)
│   │   └── miniz_oxide_c_api v0.2.3
│   │       ├── crc32fast v1.2.0 (*)
│   │       ├── libc v0.2.60 (*)
│   │       └── miniz_oxide v0.3.1
│   │           └── adler32 v1.0.3
│   │       [build-dependencies]
│   │       └── cc v1.0.38 (*)
│   ├── futures v0.1.28
│   ├── http v0.1.18
│   │   ├── bytes v0.4.12 (*)
│   │   ├── fnv v1.0.6
│   │   └── itoa v0.4.4 (*)
│   ├── hyper v0.12.33
│   │   ├── bytes v0.4.12 (*)
│   │   ├── futures v0.1.28 (*)
│   │   ├── futures-cpupool v0.1.8
│   │   │   ├── futures v0.1.28 (*)
│   │   │   └── num_cpus v1.10.1 (*)
│   │   ├── h2 v0.1.26
│   │   │   ├── byteorder v1.3.2 (*)
│   │   │   ├── bytes v0.4.12 (*)
│   │   │   ├── fnv v1.0.6 (*)
│   │   │   ├── futures v0.1.28 (*)
│   │   │   ├── http v0.1.18 (*)
│   │   │   ├── indexmap v1.0.2
│   │   │   ├── log v0.4.8 (*)
│   │   │   ├── slab v0.4.2
│   │   │   ├── string v0.2.1
│   │   │   │   └── bytes v0.4.12 (*)
│   │   │   └── tokio-io v0.1.12
│   │   │       ├── bytes v0.4.12 (*)
│   │   │       ├── futures v0.1.28 (*)
│   │   │       └── log v0.4.8 (*)
│   │   ├── http v0.1.18 (*)
│   │   ├── http-body v0.1.0
│   │   │   ├── bytes v0.4.12 (*)
│   │   │   ├── futures v0.1.28 (*)
│   │   │   ├── http v0.1.18 (*)
│   │   │   └── tokio-buf v0.1.1
│   │   │       ├── bytes v0.4.12 (*)
│   │   │       ├── either v1.5.2 (*)
│   │   │       └── futures v0.1.28 (*)
│   │   ├── httparse v1.3.4
│   │   ├── iovec v0.1.2 (*)
│   │   ├── itoa v0.4.4 (*)
│   │   ├── log v0.4.8 (*)
│   │   ├── net2 v0.2.33
│   │   │   ├── cfg-if v0.1.9 (*)
│   │   │   └── libc v0.2.60 (*)
│   │   ├── time v0.1.42 (*)
│   │   ├── tokio v0.1.22
│   │   │   ├── bytes v0.4.12 (*)
│   │   │   ├── futures v0.1.28 (*)
│   │   │   ├── mio v0.6.19
│   │   │   │   ├── iovec v0.1.2 (*)
│   │   │   │   ├── libc v0.2.60 (*)
│   │   │   │   ├── log v0.4.8 (*)
│   │   │   │   ├── net2 v0.2.33 (*)
│   │   │   │   └── slab v0.4.2 (*)
│   │   │   ├── num_cpus v1.10.1 (*)
│   │   │   ├── tokio-current-thread v0.1.6
│   │   │   │   ├── futures v0.1.28 (*)
│   │   │   │   └── tokio-executor v0.1.8
│   │   │   │       ├── crossbeam-utils v0.6.6
│   │   │   │       │   ├── cfg-if v0.1.9 (*)
│   │   │   │       │   └── lazy_static v1.4.0 (*)
│   │   │   │       └── futures v0.1.28 (*)
│   │   │   ├── tokio-executor v0.1.8 (*)
│   │   │   ├── tokio-io v0.1.12 (*)
│   │   │   ├── tokio-reactor v0.1.9
│   │   │   │   ├── crossbeam-utils v0.6.6 (*)
│   │   │   │   ├── futures v0.1.28 (*)
│   │   │   │   ├── lazy_static v1.4.0 (*)
│   │   │   │   ├── log v0.4.8 (*)
│   │   │   │   ├── mio v0.6.19 (*)
│   │   │   │   ├── num_cpus v1.10.1 (*)
│   │   │   │   ├── parking_lot v0.7.1
│   │   │   │   │   ├── lock_api v0.1.5
│   │   │   │   │   │   ├── owning_ref v0.4.0
│   │   │   │   │   │   │   └── stable_deref_trait v1.1.1
│   │   │   │   │   │   └── scopeguard v0.3.3
│   │   │   │   │   └── parking_lot_core v0.4.0
│   │   │   │   │       ├── libc v0.2.60 (*)
│   │   │   │   │       ├── rand v0.6.5
│   │   │   │   │       │   ├── libc v0.2.60 (*)
│   │   │   │   │       │   ├── rand_chacha v0.1.1
│   │   │   │   │       │   │   └── rand_core v0.3.1
│   │   │   │   │       │   │       └── rand_core v0.4.2
│   │   │   │   │       │   │   [build-dependencies]
│   │   │   │   │       │   │   └── autocfg v0.1.5 (*)
│   │   │   │   │       │   ├── rand_core v0.4.2 (*)
│   │   │   │   │       │   ├── rand_hc v0.1.0
│   │   │   │   │       │   │   └── rand_core v0.3.1 (*)
│   │   │   │   │       │   ├── rand_isaac v0.1.1
│   │   │   │   │       │   │   └── rand_core v0.3.1 (*)
│   │   │   │   │       │   ├── rand_jitter v0.1.4
│   │   │   │   │       │   │   └── rand_core v0.4.2 (*)
│   │   │   │   │       │   ├── rand_os v0.1.3
│   │   │   │   │       │   │   ├── libc v0.2.60 (*)
│   │   │   │   │       │   │   └── rand_core v0.4.2 (*)
│   │   │   │   │       │   ├── rand_pcg v0.1.2
│   │   │   │   │       │   │   └── rand_core v0.4.2 (*)
│   │   │   │   │       │   │   [build-dependencies]
│   │   │   │   │       │   │   └── autocfg v0.1.5 (*)
│   │   │   │   │       │   └── rand_xorshift v0.1.1
│   │   │   │   │       │       └── rand_core v0.3.1 (*)
│   │   │   │   │       │   [build-dependencies]
│   │   │   │   │       │   └── autocfg v0.1.5 (*)
│   │   │   │   │       └── smallvec v0.6.10 (*)
│   │   │   │   │       [build-dependencies]
│   │   │   │   │       └── rustc_version v0.2.3
│   │   │   │   │           └── semver v0.9.0
│   │   │   │   │               └── semver-parser v0.7.0
│   │   │   │   ├── slab v0.4.2 (*)
│   │   │   │   ├── tokio-executor v0.1.8 (*)
│   │   │   │   ├── tokio-io v0.1.12 (*)
│   │   │   │   └── tokio-sync v0.1.6
│   │   │   │       ├── fnv v1.0.6 (*)
│   │   │   │       └── futures v0.1.28 (*)
│   │   │   │   [dev-dependencies]
│   │   │   │   └── num_cpus v1.10.1 (*)
│   │   │   ├── tokio-tcp v0.1.3
│   │   │   │   ├── bytes v0.4.12 (*)
│   │   │   │   ├── futures v0.1.28 (*)
│   │   │   │   ├── iovec v0.1.2 (*)
│   │   │   │   ├── mio v0.6.19 (*)
│   │   │   │   ├── tokio-io v0.1.12 (*)
│   │   │   │   └── tokio-reactor v0.1.9 (*)
│   │   │   ├── tokio-threadpool v0.1.15
│   │   │   │   ├── crossbeam-deque v0.7.1
│   │   │   │   │   ├── crossbeam-epoch v0.7.2
│   │   │   │   │   │   ├── arrayvec v0.4.11
│   │   │   │   │   │   │   └── nodrop v0.1.13
│   │   │   │   │   │   ├── cfg-if v0.1.9 (*)
│   │   │   │   │   │   ├── crossbeam-utils v0.6.6 (*)
│   │   │   │   │   │   ├── lazy_static v1.4.0 (*)
│   │   │   │   │   │   ├── memoffset v0.5.1
│   │   │   │   │   │   │   [build-dependencies]
│   │   │   │   │   │   │   └── rustc_version v0.2.3 (*)
│   │   │   │   │   │   └── scopeguard v1.0.0
│   │   │   │   │   └── crossbeam-utils v0.6.6 (*)
│   │   │   │   ├── crossbeam-queue v0.1.2
│   │   │   │   │   └── crossbeam-utils v0.6.6 (*)
│   │   │   │   ├── crossbeam-utils v0.6.6 (*)
│   │   │   │   ├── futures v0.1.28 (*)
│   │   │   │   ├── log v0.4.8 (*)
│   │   │   │   ├── num_cpus v1.10.1 (*)
│   │   │   │   ├── rand v0.6.5 (*)
│   │   │   │   ├── slab v0.4.2 (*)
│   │   │   │   └── tokio-executor v0.1.8 (*)
│   │   │   └── tokio-timer v0.2.11
│   │   │       ├── crossbeam-utils v0.6.6 (*)
│   │   │       ├── futures v0.1.28 (*)
│   │   │       ├── slab v0.4.2 (*)
│   │   │       └── tokio-executor v0.1.8 (*)
│   │   │   [dev-dependencies]
│   │   │   └── num_cpus v1.10.1 (*)
│   │   ├── tokio-buf v0.1.1 (*)
│   │   ├── tokio-executor v0.1.8 (*)
│   │   ├── tokio-io v0.1.12 (*)
│   │   ├── tokio-reactor v0.1.9 (*)
│   │   ├── tokio-tcp v0.1.3 (*)
│   │   ├── tokio-threadpool v0.1.15 (*)
│   │   ├── tokio-timer v0.2.11 (*)
│   │   └── want v0.2.0
│   │       ├── futures v0.1.28 (*)
│   │       ├── log v0.4.8 (*)
│   │       └── try-lock v0.2.2
│   │   [build-dependencies]
│   │   └── rustc_version v0.2.3 (*)
│   ├── hyper-tls v0.3.2
│   │   ├── bytes v0.4.12 (*)
│   │   ├── futures v0.1.28 (*)
│   │   ├── hyper v0.12.33 (*)
│   │   ├── native-tls v0.2.3
│   │   │   ├── log v0.4.8 (*)
│   │   │   ├── openssl v0.10.24
│   │   │   │   ├── bitflags v1.1.0
│   │   │   │   ├── cfg-if v0.1.9 (*)
│   │   │   │   ├── foreign-types v0.3.2
│   │   │   │   │   └── foreign-types-shared v0.1.1
│   │   │   │   ├── lazy_static v1.4.0 (*)
│   │   │   │   ├── libc v0.2.60 (*)
│   │   │   │   └── openssl-sys v0.9.48
│   │   │   │       └── libc v0.2.60 (*)
│   │   │   │       [build-dependencies]
│   │   │   │       ├── autocfg v0.1.5 (*)
│   │   │   │       ├── cc v1.0.38 (*)
│   │   │   │       └── pkg-config v0.3.15
│   │   │   ├── openssl-probe v0.1.2
│   │   │   └── openssl-sys v0.9.48 (*)
│   │   └── tokio-io v0.1.12 (*)
│   ├── log v0.4.8 (*)
│   ├── mime v0.3.13
│   │   └── unicase v2.4.0
│   │       [build-dependencies]
│   │       └── version_check v0.1.5 (*)
│   ├── mime_guess v2.0.1
│   │   ├── mime v0.3.13 (*)
│   │   └── unicase v2.4.0 (*)
│   │   [build-dependencies]
│   │   └── unicase v2.4.0 (*)
│   ├── native-tls v0.2.3 (*)
│   ├── serde v1.0.99 (*)
│   ├── serde_json v1.0.40 (*)
│   ├── serde_urlencoded v0.5.5
│   │   ├── dtoa v0.4.4
│   │   ├── itoa v0.4.4 (*)
│   │   ├── serde v1.0.99 (*)
│   │   └── url v1.7.2 (*)
│   ├── time v0.1.42 (*)
│   ├── tokio v0.1.22 (*)
│   ├── tokio-executor v0.1.8 (*)
│   ├── tokio-io v0.1.12 (*)
│   ├── tokio-threadpool v0.1.15 (*)
│   ├── tokio-timer v0.2.11 (*)
│   ├── url v1.7.2 (*)
│   └── uuid v0.7.4
│       └── rand v0.6.5 (*)
│   [dev-dependencies]
│   ├── bytes v0.4.12 (*)
│   ├── serde v1.0.99 (*)
│   └── tokio v0.1.22 (*)
```
:scream: 