### PR TITLE
Add benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,20 @@ name = "kv12ntfs"
 path = "tests/read_kv1.rs"
 required-features = ["proj"]
 
+[[bench]]
+name = "read_kv1"
+path = "benches/read_kv1.rs"
+required-features = ["proj"]
+
 [[test]]
 name = "transxchange2ntfs"
 path = "tests/read_transxchange.rs"
 required-features = ["proj"]
+
+[[bench]]
+name = "read_transxchange"
+path = "benches/read_transxchange.rs"
+required-features = ["transxchange"]
 
 [dev-dependencies]
 approx = "0.3"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ If you want to use [PROJ](https://proj.org/) in your code, you can if you
 activate the `proj` feature (`cargo build --features=proj`). Then don't forget
 to protect your code with `#[cfg(feature="proj")]`.
 
+## Benchmarking
+A few benchmarks are available if you want to compare performance of a new
+feature or of an optimization. Benchmarking functionality is only available in
+Rust Nightly so to run them, you can do the following.
+
+```
+cargo +nightly bench --all-features
+```
+
+Of course, if you need to run one specific bench, you can refer to a specific
+bench name in `benches/`.
+
+```
+rustup run nightly cargo bench read_kv1 --features proj
+```
+
 ## Converting from GTFS to NTFS
 
 NTFS needs a `Dataset` and a `Contributor`.

--- a/benches/apply_rules.rs
+++ b/benches/apply_rules.rs
@@ -1,0 +1,89 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate test;
+
+use std::path::Path;
+use test::Bencher;
+use transit_model::{apply_rules, ntfs};
+
+#[bench]
+fn apply_rules_none(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        apply_rules::apply_rules(
+            ntfs::read("./tests/fixtures/apply_rules/input").unwrap(),
+            vec![],
+            vec![],
+            None,
+            Path::new("./tests/fixtures/apply_rules/output_report/report.json").to_path_buf(),
+        )
+        .unwrap()
+    });
+}
+
+#[bench]
+fn apply_rules_complementary_codes(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        apply_rules::apply_rules(
+            ntfs::read("./tests/fixtures/apply_rules/input").unwrap(),
+            vec![
+                Path::new("./tests/fixtures/apply_rules/complementary_codes_rules.txt")
+                    .to_path_buf(),
+            ],
+            vec![],
+            None,
+            Path::new(
+                "./tests/fixtures/apply_rules/output_report/report_apply_complementary_codes.json",
+            )
+            .to_path_buf(),
+        )
+        .unwrap()
+    });
+}
+
+#[bench]
+fn apply_rules_property(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        apply_rules::apply_rules(
+            ntfs::read("./tests/fixtures/apply_rules/input").unwrap(),
+            vec![
+                Path::new("./tests/fixtures/apply_rules/complementary_codes_rules.txt")
+                    .to_path_buf(),
+            ],
+            vec![Path::new("./tests/fixtures/apply_rules/property_rules.txt").to_path_buf()],
+            None,
+            Path::new("./tests/fixtures/apply_rules/output_report/report_apply_property.json")
+                .to_path_buf(),
+        )
+        .unwrap()
+    });
+}
+
+#[bench]
+fn apply_rules_network_consolidation(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        apply_rules::apply_rules(
+            ntfs::read("./tests/fixtures/apply_rules/input").unwrap(),
+            vec![],
+            vec![],
+            Some(Path::new("./tests/fixtures/apply_rules/ntw_consolidation.json").to_path_buf()),
+            Path::new("./tests/fixtures/apply_rules/output_report/report.json").to_path_buf(),
+        )
+        .unwrap()
+    });
+}

--- a/benches/filter_ntfs.rs
+++ b/benches/filter_ntfs.rs
@@ -1,0 +1,47 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+use transit_model::{
+    ntfs,
+    ntfs::{filter, filter::Action::*},
+};
+
+#[bench]
+fn filter_ntfs_extract(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        filter::filter(
+            ntfs::read("./tests/fixtures/filter_ntfs/input").unwrap(),
+            Extract,
+            vec![String::from("network1")],
+        )
+    });
+}
+
+#[bench]
+fn filter_ntfs_remove(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        filter::filter(
+            ntfs::read("./tests/fixtures/filter_ntfs/input").unwrap(),
+            Remove,
+            vec![String::from("network1")],
+        )
+    });
+}

--- a/benches/read_gtfs.rs
+++ b/benches/read_gtfs.rs
@@ -1,0 +1,29 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+use transit_model::gtfs;
+
+#[bench]
+fn read_gtfs(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        gtfs::read_from_path("./tests/fixtures/gtfs2ntfs/minimal/input", None, None).unwrap()
+    });
+}

--- a/benches/read_kv1.rs
+++ b/benches/read_kv1.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+use transit_model::kv1;
+
+#[bench]
+fn read_kv1(bencher: &mut Bencher) {
+    bencher.iter(|| kv1::read_from_path("./tests/fixtures/kv12ntfs/input", None, None).unwrap());
+}

--- a/benches/read_ntfs.rs
+++ b/benches/read_ntfs.rs
@@ -1,0 +1,27 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+use transit_model::ntfs;
+
+#[bench]
+fn read_ntfs(bencher: &mut Bencher) {
+    bencher.iter(|| ntfs::read("./tests/fixtures/ntfs2ntfs/fares").unwrap());
+}

--- a/benches/read_transxchange.rs
+++ b/benches/read_transxchange.rs
@@ -1,0 +1,35 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+use transit_model::transxchange;
+
+#[bench]
+fn read_transxchange(bencher: &mut Bencher) {
+    bencher.iter(|| {
+        transxchange::read(
+            "./tests/fixtures/transxchange2ntfs/input/transxchange",
+            "./tests/fixtures/transxchange2ntfs/input/naptan",
+            None,
+            None,
+        )
+        .unwrap()
+    });
+}


### PR DESCRIPTION
A proposition to bring some benchmarks in the project. This would not be run on CI (bench is still a nightly feature for now) but that could help to evaluate a solution or an optimization.

I didn't create a bench for every possible functions for which it might make sense. But this PR should set a sufficient base to write any new bench needed.

Below the results on my machine. Obviously, it's only interesting to do comparative run on the same machine (a before/after comparison in the same condition).
```
     Running target/release/deps/apply_rules-c8e83e1dc1c838b0                                                                             [50/9464]
                                                                                                                                                   
running 4 tests                                                                                                                                    
test apply_rules_complementary_codes   ... bench:     915,235 ns/iter (+/- 86,040)
test apply_rules_network_consolidation ... bench:   1,021,447 ns/iter (+/- 18,795)
test apply_rules_none                  ... bench:     853,797 ns/iter (+/- 58,342)                                                                
test apply_rules_property              ... bench:   1,128,967 ns/iter (+/- 43,209)

                                                                                                                                                  
test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
                                                                                                                                                  
     Running target/release/deps/filter_ntfs-38914f3bd4ade022

running 2 tests
test filter_ntfs_extract ... bench:     391,130 ns/iter (+/- 172,297)
test filter_ntfs_remove  ... bench:     396,004 ns/iter (+/- 21,594)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out

     Running target/release/deps/read_gtfs-37a27e2a577929da

running 1 test
test read_gtfs ... bench:     264,400 ns/iter (+/- 17,640)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/read_kv1-aada2dddfd06e7be

running 1 test
test read_kv1 ... bench:  22,817,930 ns/iter (+/- 2,364,587)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/read_ntfs-537635221bb1d197

running 1 test
test read_ntfs ... bench:     412,235 ns/iter (+/- 26,391)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/read_transxchange-de100c03e325066c

running 1 test
test read_transxchange ... bench:  23,400,540 ns/iter (+/- 1,993,550)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

```