### PR TITLE
Use an ordered comparison structure to facilitate diff

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,7 +16,7 @@
 
 use chrono::{NaiveDate, NaiveDateTime};
 use pretty_assertions::assert_eq;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::fs::File;
 use std::io::{prelude::*, BufReader};
@@ -32,11 +32,11 @@ pub fn get_file_content<P: AsRef<Path>>(path: P) -> String {
 
     output_contents
 }
-pub fn get_lines_content<P: AsRef<Path>>(path: P) -> HashSet<String> {
+pub fn get_lines_content<P: AsRef<Path>>(path: P) -> BTreeSet<String> {
     let path = path.as_ref();
     let file = File::open(path).unwrap_or_else(|_| panic!("file {:?} not found", path));
     let reader = BufReader::new(file);
-    let mut set = HashSet::new();
+    let mut set = BTreeSet::new();
     for result_line in reader.lines() {
         let line = result_line.expect(&format!("Cannot parse as a line in file {:?}", path));
         set.insert(line);


### PR DESCRIPTION
Using an ordered structure will help to understand what's going on when a test is failing. Below is an example of the exact same test with the same error but one with the `HashSet` (the code today) and one with `BTreeSet` (the proposition of this PR).

### With `HashSet`
![hashset_diff](https://user-images.githubusercontent.com/2520723/63852210-11103e80-c998-11e9-8c75-3aa7dd83258a.png)

### With `BTreeSet`
![btreeset_diff](https://user-images.githubusercontent.com/2520723/63852282-3604b180-c998-11e9-8c88-329c94a7ce46.png)

Much easier to understand what's going on in the second case.