### PR TITLE
Remove cargo cache in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 language: rust
-cache: cargo
 rust:
 - stable
 - beta


### PR DESCRIPTION
The build in TravisCI is crashing a lot because of some timeout during the cache loading.  I did try a build on TravisCI without cache to compare the build time and it doesn't seem like the build time is affected (or if it is, it's a little bit shorter in average).

I also took a look in serde project which doesn't seems to use `cache: cargo` (note however that their build time is much shorter).

[This blog post](https://levans.fr/rust_travis_cache.html) seems to propose an alternative solution. But removing `~/.cargo/registry` and `target/` from the cache basically remove everything from the cache. What's left is:
- `~/.cargo/bin` which are the binaries for `cargo` (so we might win a little by avoiding a reinstallation of Cargo)
- `~/.cargo/.crates.toml`, contains only extension to cargo install, as a text file less than 10 lines in probably the worst case
- `~/.cargo/.package-cache`, not sure what it is but it is empty on my machine
- `~/.cargo/env`, a one-liner to export `PATH`
- `~/.cargo/git`, the only one I'm not sure what it is and how it can impact the build time...
