### PR TITLE
Make GTFS read and FileHandler public

### DIFF
--- a/src/common_format.rs
+++ b/src/common_format.rs
@@ -15,9 +15,9 @@
 // <http://www.gnu.org/licenses/>.
 
 use crate::collection::*;
+use crate::file_handler::FileHandler;
 use crate::model::Collections;
 use crate::objects::{self, Date, ExceptionType};
-use crate::read_utils::FileHandler;
 use crate::utils::*;
 use crate::utils::{de_from_date_string, ser_from_naive_date};
 use crate::vptranslator::translate;

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -1,0 +1,113 @@
+// Copyright 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+use crate::Result;
+use failure::{format_err, ResultExt};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+pub trait FileHandler
+where
+    Self: std::marker::Sized,
+{
+    type Reader: std::io::Read;
+
+    fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)>;
+
+    fn get_file(self, name: &str) -> Result<(Self::Reader, PathBuf)> {
+        let (reader, path) = self.get_file_if_exists(name)?;
+        Ok((
+            reader.ok_or_else(|| format_err!("file {:?} not found", path))?,
+            path,
+        ))
+    }
+}
+
+/// PathFileHandler is used to read files for a directory
+pub struct PathFileHandler {
+    base_path: PathBuf,
+}
+
+impl PathFileHandler {
+    pub fn new(path: PathBuf) -> Self {
+        PathFileHandler { base_path: path }
+    }
+}
+
+impl<'a> FileHandler for &'a mut PathFileHandler {
+    type Reader = File;
+    fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)> {
+        let f = self.base_path.join(name);
+        if f.exists() {
+            Ok((Some(File::open(&f).with_context(ctx_from_path!(&f))?), f))
+        } else {
+            Ok((None, f))
+        }
+    }
+}
+
+/// ZipHandler is a wrapper around a ZipArchive
+/// It provides a way to access the archive's file by their names
+///
+/// Unlike ZipArchive, it gives access to a file by it's name not regarding it's path in the ZipArchive
+/// It thus cannot be correct if there are 2 files with the same name in the archive,
+/// but for transport data if will make it possible to handle a zip with a sub directory
+pub struct ZipHandler<R: std::io::Seek + std::io::Read> {
+    archive: zip::ZipArchive<R>,
+    archive_path: PathBuf,
+    index_by_name: BTreeMap<String, usize>,
+}
+
+impl<R> ZipHandler<R>
+where
+    R: std::io::Seek + std::io::Read,
+{
+    pub fn new<P: AsRef<Path>>(r: R, path: P) -> Result<Self> {
+        let mut archive = zip::ZipArchive::new(r)?;
+        Ok(ZipHandler {
+            index_by_name: Self::files_by_name(&mut archive),
+            archive,
+            archive_path: path.as_ref().to_path_buf(),
+        })
+    }
+
+    fn files_by_name(archive: &mut zip::ZipArchive<R>) -> BTreeMap<String, usize> {
+        (0..archive.len())
+            .filter_map(|i| {
+                let file = archive.by_index(i).ok()?;
+                // we get the name of the file, not regarding it's patch in the ZipArchive
+                let real_name = Path::new(file.name()).file_name()?;
+                let real_name: String = real_name.to_str()?.into();
+                Some((real_name, i))
+            })
+            .collect()
+    }
+}
+
+impl<'a, R> FileHandler for &'a mut ZipHandler<R>
+where
+    R: std::io::Seek + std::io::Read,
+{
+    type Reader = zip::read::ZipFile<'a>;
+    fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)> {
+        let p = self.archive_path.join(name);
+        match self.index_by_name.get(name) {
+            None => Ok((None, p)),
+            Some(i) => Ok((Some(self.archive.by_index(*i)?), p)),
+        }
+    }
+}

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -22,6 +22,7 @@ mod write;
 use crate::{
     collection::{CollectionWithId, Idx},
     common_format::{manage_calendars, write_calendar_dates, Availability},
+    file_handler,
     gtfs::read::EquipmentList,
     model::{Collections, Model},
     objects,
@@ -236,13 +237,14 @@ struct Shape {
     sequence: u32,
 }
 
-fn read<H>(
+/// Read GTFS
+pub fn read<H>(
     file_handler: &mut H,
     config_path: Option<impl AsRef<Path>>,
     prefix: Option<String>,
 ) -> Result<Model>
 where
-    for<'a> &'a mut H: read_utils::FileHandler,
+    for<'a> &'a mut H: file_handler::FileHandler,
 {
     let mut collections = Collections::default();
     let mut equipments = EquipmentList::default();
@@ -298,7 +300,7 @@ pub fn read_from_path<P: AsRef<Path>>(
     config_path: Option<P>,
     prefix: Option<String>,
 ) -> Result<Model> {
-    let mut file_handle = read_utils::PathFileHandler::new(p.as_ref().to_path_buf());
+    let mut file_handle = file_handler::PathFileHandler::new(p.as_ref().to_path_buf());
     read(&mut file_handle, config_path, prefix)
 }
 
@@ -317,7 +319,7 @@ pub fn read_from_zip<P: AsRef<Path>>(
     prefix: Option<String>,
 ) -> Result<Model> {
     let reader = File::open(p.as_ref())?;
-    let mut file_handle = read_utils::ZipHandler::new(reader, p)?;
+    let mut file_handle = file_handler::ZipHandler::new(reader, p)?;
     read(&mut file_handle, config_path, prefix)
 }
 

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -20,12 +20,13 @@ use super::{
 };
 use crate::collection::{Collection, CollectionWithId, Id};
 use crate::common_format::Availability;
+use crate::file_handler::FileHandler;
 use crate::model::Collections;
 use crate::objects::{
     self, CommentLinksT, Coord, KeysValues, StopTime as NtfsStopTime, StopType, Time,
     TransportType, VehicleJourney,
 };
-use crate::read_utils::{read_collection, read_objects, FileHandler};
+use crate::read_utils::{read_collection, read_objects};
 use crate::utils::*;
 use crate::Result;
 use csv;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub mod collection;
 pub(crate) mod common_format;
 #[macro_use]
 pub mod objects;
+#[doc(hidden)]
+pub mod file_handler;
 pub mod gtfs;
 pub mod hellogo_fares;
 #[cfg(feature = "proj")]

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -23,9 +23,9 @@ mod read;
 mod write;
 
 use crate::common_format;
+use crate::file_handler;
 use crate::model::{Collections, Model};
 use crate::objects::*;
-use crate::read_utils;
 use crate::utils::*;
 use crate::Result;
 use chrono::NaiveDateTime;
@@ -148,7 +148,7 @@ fn has_fares_v1(collections: &Collections) -> bool {
 /// files in the given directory.
 pub fn read<P: AsRef<path::Path>>(path: P) -> Result<Model> {
     let path = path.as_ref();
-    let mut file_handle = read_utils::PathFileHandler::new(path.to_path_buf());
+    let mut file_handle = file_handler::PathFileHandler::new(path.to_path_buf());
 
     info!("Loading NTFS from {:?}", path);
     let mut collections = Collections::default();

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -16,17 +16,17 @@
 
 use crate::{
     collection::{CollectionWithId, Id},
+    file_handler::FileHandler,
     objects::{self, Contributor},
     Result,
 };
-use failure::{format_err, ResultExt};
+use failure::ResultExt;
 use log::info;
 use serde::Deserialize;
 use serde_json;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
 use std::path;
-use std::path::{Path, PathBuf};
 use std::result::Result as StdResult;
 
 #[derive(Deserialize, Debug)]
@@ -100,98 +100,6 @@ pub fn set_dataset_validity_period(
     }
 
     Ok(())
-}
-
-pub trait FileHandler
-where
-    Self: std::marker::Sized,
-{
-    type Reader: std::io::Read;
-
-    fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)>;
-
-    fn get_file(self, name: &str) -> Result<(Self::Reader, PathBuf)> {
-        let (reader, path) = self.get_file_if_exists(name)?;
-        Ok((
-            reader.ok_or_else(|| format_err!("file {:?} not found", path))?,
-            path,
-        ))
-    }
-}
-
-/// PathFileHandler is used to read files for a directory
-pub struct PathFileHandler {
-    base_path: PathBuf,
-}
-
-impl PathFileHandler {
-    pub fn new(path: PathBuf) -> Self {
-        PathFileHandler { base_path: path }
-    }
-}
-
-impl<'a> FileHandler for &'a mut PathFileHandler {
-    type Reader = File;
-    fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)> {
-        let f = self.base_path.join(name);
-        if f.exists() {
-            Ok((Some(File::open(&f).with_context(ctx_from_path!(&f))?), f))
-        } else {
-            Ok((None, f))
-        }
-    }
-}
-
-/// ZipHandler is a wrapper around a ZipArchive
-/// It provides a way to access the archive's file by their names
-///
-/// Unlike ZipArchive, it gives access to a file by it's name not regarding it's path in the ZipArchive
-/// It thus cannot be correct if there are 2 files with the same name in the archive,
-/// but for transport data if will make it possible to handle a zip with a sub directory
-pub struct ZipHandler<R: std::io::Seek + std::io::Read> {
-    archive: zip::ZipArchive<R>,
-    archive_path: PathBuf,
-    index_by_name: BTreeMap<String, usize>,
-}
-
-impl<R> ZipHandler<R>
-where
-    R: std::io::Seek + std::io::Read,
-{
-    pub fn new<P: AsRef<Path>>(r: R, path: P) -> Result<Self> {
-        let mut archive = zip::ZipArchive::new(r)?;
-        Ok(ZipHandler {
-            index_by_name: Self::files_by_name(&mut archive),
-            archive,
-            archive_path: path.as_ref().to_path_buf(),
-        })
-    }
-
-    fn files_by_name(archive: &mut zip::ZipArchive<R>) -> BTreeMap<String, usize> {
-        (0..archive.len())
-            .filter_map(|i| {
-                let file = archive.by_index(i).ok()?;
-                // we get the name of the file, not regarding it's patch in the ZipArchive
-                let real_name = Path::new(file.name()).file_name()?;
-                let real_name: String = real_name.to_str()?.into();
-                Some((real_name, i))
-            })
-            .collect()
-    }
-}
-
-impl<'a, R> FileHandler for &'a mut ZipHandler<R>
-where
-    R: std::io::Seek + std::io::Read,
-{
-    type Reader = zip::read::ZipFile<'a>;
-    fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)> {
-        let p = self.archive_path.join(name);
-        match self.index_by_name.get(name) {
-            None => Ok((None, p)),
-            Some(i) => Ok((Some(self.archive.by_index(*i)?), p)),
-        }
-    }
 }
 
 /// Read a vector of objects from a zip in a file_handler


### PR DESCRIPTION
`read_url` was removed in PR https://github.com/CanalTP/transit_model/pull/325/files which makes impossible to request and read a gtfs from the outside.

- add a new module with FileHandler trait and its implementations
- made `gtfs::read` public

another solution would be to add a feature (I will make another draft)
