### PR TITLE
Upgrade network/company name if possible

### DIFF
--- a/fixtures/transxchange2ntfs/input/transxchange/no-mode.xml
+++ b/fixtures/transxchange2ntfs/input/transxchange/no-mode.xml
@@ -2,8 +2,10 @@
 <TransXChange xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.transxchange.org.uk/ http://www.transxchange.org.uk/schema/2.1/TransXChange_general.xsd" xmlns="http://www.transxchange.org.uk/">
   <Operators>
     <Operator id="O1">
-      <OperatorCode>SSWK</OperatorCode>
-      <OperatorShortName>Stagecoach South Kales</OperatorShortName>
+      <OperatorCode>SSWL</OperatorCode>
+      <OperatorShortName>Stagecoach South Wales</OperatorShortName>
+      <WebSite>www.example.com</WebSite>
+      <ContactTelephoneNumber>123-456-7890</ContactTelephoneNumber>
     </Operator>
   </Operators>
   <Services>

--- a/fixtures/transxchange2ntfs/input/transxchange/simple.xml
+++ b/fixtures/transxchange2ntfs/input/transxchange/simple.xml
@@ -43,7 +43,6 @@
   <Operators>
     <Operator id="O1">
       <OperatorCode>SSWL</OperatorCode>
-      <OperatorShortName>Stagecoach South Wales</OperatorShortName>
       <WebSite>www.example.com</WebSite>
       <ContactTelephoneNumber>123-456-7890</ContactTelephoneNumber>
     </Operator>

--- a/fixtures/transxchange2ntfs/output/ntfs/companies.txt
+++ b/fixtures/transxchange2ntfs/output/ntfs/companies.txt
@@ -1,4 +1,3 @@
 company_id,company_name,company_address,company_url,company_mail,company_phone
 prefix:SSWL,Stagecoach South Wales,,,,
 prefix:ANSL,Phil Anslow,,,,
-prefix:SSWK,Stagecoach South Kales,,,,

--- a/fixtures/transxchange2ntfs/output/ntfs/lines.txt
+++ b/fixtures/transxchange2ntfs/output/ntfs/lines.txt
@@ -1,4 +1,4 @@
 line_id,line_code,line_name,forward_line_name,forward_direction,backward_line_name,backward_direction,line_color,line_text_color,line_sort_order,network_id,commercial_mode_id,geometry_id,line_opening_time,line_closing_time
 prefix:SCAO812:SL1,812,Pontypool Town Hall - Pontypool College,Pontypool College,,Pontypool Town Hall,,,,,prefix:SSWL,Ferry,,,
 prefix:SCAO812:SL2,811,Pontypool Town Hall - Pontypool College,Pontypool College,,Pontypool Town Hall,,,,,prefix:SSWL,Ferry,,,
-prefix:SCAO813:SL1,813,Pontypool Town Kall - Pontypool Kollege,Pontypool Kollege,,Pontypool Town Kall,,,,,prefix:SSWK,Bus,,,
+prefix:SCAO813:SL1,813,Pontypool Town Kall - Pontypool Kollege,Pontypool Kollege,,Pontypool Town Kall,,,,,prefix:SSWL,Bus,,,

--- a/fixtures/transxchange2ntfs/output/ntfs/networks.txt
+++ b/fixtures/transxchange2ntfs/output/ntfs/networks.txt
@@ -1,3 +1,2 @@
 network_id,network_name,network_url,network_timezone,network_lang,network_phone,network_address,network_sort_order
 prefix:SSWL,Stagecoach South Wales,www.example.com,Europe/London,,123-456-7890,,
-prefix:SSWK,Stagecoach South Kales,,Europe/London,,,,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub mod hellogo_fares;
 #[cfg(feature = "proj")]
 pub mod kv1;
 pub mod merge_stop_areas;
+mod merge_with;
+use merge_with::MergeWith;
 mod minidom_utils;
 pub mod model;
 pub mod ntfs;

--- a/src/merge_with.rs
+++ b/src/merge_with.rs
@@ -1,0 +1,116 @@
+use crate::collection::{CollectionWithId, Id};
+
+pub trait MergeWith<T> {
+    fn merge_with<I, F>(&mut self, iterator: I, f: F)
+    where
+        F: FnMut(&mut Self, &T),
+        I: IntoIterator<Item = T>;
+}
+
+impl<V> MergeWith<V> for CollectionWithId<V>
+where
+    V: Id<V>,
+{
+    fn merge_with<I, F>(&mut self, iterator: I, mut f: F)
+    where
+        F: FnMut(&mut Self, &V),
+        I: IntoIterator<Item = V>,
+    {
+        for e in iterator {
+            if self.get_mut(e.id()).is_some() {
+                f(self, &e);
+            } else {
+                let _ = self.push(e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct ObjectId<'a> {
+        id: &'a str,
+        name: &'a str,
+    }
+
+    impl Id<ObjectId<'_>> for ObjectId<'_> {
+        fn id(&self) -> &str {
+            self.id
+        }
+        fn set_id(&mut self, _id: String) {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn it_works() {
+        let mut collection = CollectionWithId::default();
+        let _ = collection.push(ObjectId {
+            id: "foo",
+            ..Default::default()
+        });
+        let vec = vec![ObjectId {
+            id: "bar",
+            ..Default::default()
+        }];
+        collection.merge_with(vec, |_, _| {
+            // Should not go in there
+            assert!(false)
+        });
+        assert!(collection.get("foo").is_some());
+        assert!(collection.get("bar").is_some());
+    }
+
+    #[test]
+    fn empty_iterator() {
+        let mut collection = CollectionWithId::default();
+        let _ = collection.push(ObjectId {
+            id: "foo",
+            ..Default::default()
+        });
+        let vec = vec![];
+        collection.merge_with(vec, |_, _| {
+            // Should not go in there
+            assert!(false)
+        });
+        assert!(collection.get("foo").is_some());
+    }
+
+    #[test]
+    fn empty_collections() {
+        let mut collection: CollectionWithId<ObjectId> = CollectionWithId::default();
+        let vec = vec![ObjectId {
+            id: "bar",
+            ..Default::default()
+        }];
+        collection.merge_with(vec, |_, _| {
+            // Should not go in there
+            assert!(false)
+        });
+        assert!(collection.get("bar").is_some());
+    }
+
+    #[test]
+    fn merge() {
+        let mut collection = CollectionWithId::default();
+        let _ = collection.push(ObjectId {
+            id: "foo",
+            name: "Bob",
+        });
+        let vec = vec![ObjectId {
+            id: "foo",
+            name: "Marley",
+        }];
+        collection.merge_with(vec, |collection, to_merge| {
+            let mut foo = collection.get_mut("foo").unwrap();
+            assert_eq!(foo.name, "Bob");
+            assert_eq!(to_merge.id, "foo");
+            foo.name = to_merge.name;
+        });
+        let foo = collection.get("foo").unwrap();
+        assert_eq!(foo.name, "Marley");
+    }
+}


### PR DESCRIPTION
I did a `trait` for `merge_with()` but I'm not yet sure it's the best option (this is why I have this PR as draft for now).  The idea was to do something similar to the [`Extend`](https://doc.rust-lang.org/std/iter/trait.Extend.html) trait. That said, `MergeWith` is implemented only for `CollectionWithId` so it could just be a new method of this `struct`, without any notion of a `trait` for now.

Another option would be to have the trait defined with a closure that would take only the two elements in conflict (instead of the full collection and the element to merge that is in conflict, see #345).