### PR TITLE
Create netex_utils module with 'get_value_in_keylist'

### DIFF
--- a/src/hellogo_fares/read.rs
+++ b/src/hellogo_fares/read.rs
@@ -14,11 +14,11 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use super::utils;
-use super::utils::FrameType;
+use super::{utils, utils::FrameType};
 use crate::{
     minidom_utils::{TryAttribute, TryOnlyChild},
     model::Collections,
+    netex_utils,
     objects::*,
     AddPrefix, Result,
 };
@@ -169,7 +169,7 @@ fn get_line_id(fare_frame: &Element, service_frame: &Element) -> Result<String> 
                     .map(|id| id == line_ref)
                     .unwrap_or(false)
             })
-            .map(|line| utils::get_value_in_keylist(line, "KV1PlanningLijnNummer"))
+            .map(|line| netex_utils::get_value_in_keylist(line, "KV1PlanningLijnNummer"))
             .collect::<Result<_>>()?;
         if values.len() == 1 {
             Ok(values[0].clone())
@@ -300,9 +300,9 @@ fn load_netex_fares(collections: &mut Collections, root: &Element) -> Result<()>
                     continue;
                 };
                 let boarding_fee: Decimal =
-                    utils::get_value_in_keylist(fare_frame, "EntranceRateWrtCurrency")?;
+                    netex_utils::get_value_in_keylist(fare_frame, "EntranceRateWrtCurrency")?;
                 let rounding_rule: Decimal =
-                    utils::get_value_in_keylist(fare_frame, "RoundingWrtCurrencyRule")?;
+                    netex_utils::get_value_in_keylist(fare_frame, "RoundingWrtCurrencyRule")?;
                 let rounding_rule = rounding_rule.normalize().scale();
                 let currency = utils::get_currency(fare_frame)?;
                 let distance_matrix_elements = utils::get_distance_matrix_elements(fare_frame)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod minidom_utils;
 pub mod model;
 #[cfg(feature = "proj")]
 pub mod netex_idf;
+mod netex_utils;
 pub mod ntfs;
 mod read_utils;
 #[doc(hidden)]

--- a/src/netex_utils/mod.rs
+++ b/src/netex_utils/mod.rs
@@ -1,0 +1,86 @@
+use crate::{minidom_utils::TryOnlyChild, Result};
+use failure::{bail, format_err};
+use minidom::Element;
+use std::str::FromStr;
+
+pub fn get_value_in_keylist<F>(element: &Element, key: &str) -> Result<F>
+where
+    F: FromStr,
+{
+    let values = element
+        .try_only_child("KeyList")?
+        .children()
+        .filter(|key_value| match key_value.try_only_child("Key") {
+            Ok(k) => k.text() == key,
+            _ => false,
+        })
+        .map(|key_value| key_value.try_only_child("Value"))
+        .collect::<Result<Vec<_>>>()?;
+    if values.len() != 1 {
+        bail!(
+            "Failed to find a unique key '{}' in '{}'",
+            key,
+            element.name()
+        )
+    }
+    values[0]
+        .text()
+        .parse()
+        .map_err(|_| format_err!("Failed to get the value out of 'KeyList' for key '{}'", key))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    mod value_in_keylist {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn has_value() {
+            let xml = r#"<root>
+                    <KeyList>
+                        <KeyValue>
+                            <Key>key</Key>
+                            <Value>42</Value>
+                        </KeyValue>
+                    </KeyList>
+                </root>"#;
+            let root: Element = xml.parse().unwrap();
+            let value: u32 = get_value_in_keylist(&root, "key").unwrap();
+            assert_eq!(value, 42);
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to find a child \\'KeyList\\' in element \\'root\\'")]
+        fn no_keylist_found() {
+            let xml = r#"<root />"#;
+            let root: Element = xml.parse().unwrap();
+            get_value_in_keylist::<u32>(&root, "key").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to find a unique key \\'key\\' in \\'root\\'")]
+        fn no_key_found() {
+            let xml = r#"<root>
+                    <KeyList />
+                </root>"#;
+            let root: Element = xml.parse().unwrap();
+            get_value_in_keylist::<u32>(&root, "key").unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to find a child \\'Value\\' in element \\'KeyValue\\'")]
+        fn no_value_found() {
+            let xml = r#"<root>
+                    <KeyList>
+                        <KeyValue>
+                            <Key>key</Key>
+                        </KeyValue>
+                    </KeyList>
+                </root>"#;
+            let root: Element = xml.parse().unwrap();
+            get_value_in_keylist::<u32>(&root, "key").unwrap();
+        }
+    }
+}


### PR DESCRIPTION
Starting to move some `utils` out of hellogo fares in a separate module so we can use them in Netex IDF. This PR is only a start (to keep the PR small), I'm also working on getting more in this `utils` module (like stuff about the frames).