### PR TITLE
Add mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,25 @@
+pull_request_rules:
+  - name: automatic merge when CI passes and 2 reviews
+    conditions:
+      - "#approved-reviews-by>=2"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
+      - status-success=continuous-integration/travis-ci/pr
+      - base=master
+      - label!=dot_not_merge
+      - label!=wip
+      - author=@CoreToolsTeam
+    actions:
+      merge:
+        method: merge
+        strict: true
+  - name: delete head branch after merge
+    conditions: []
+    actions:
+      delete_head_branch: {}
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews: {}


### PR DESCRIPTION
Automatically merge PR done by @CanalTP/coreteam that have

- at least 2 approved reviews
- no comment or request for change reviews
- all requested reviewer have approved
- all CI tests are ok
- no label wip, dot_not_merge
- PR are rebased on master if needed and tests are rerun before merge.
- Reviews are dismissed when a push occurs.


see https://doc.mergify.io/index.html for documentation