### PR TITLE
Refactor of FrameType

### DIFF
--- a/src/hellogo_fares/read.rs
+++ b/src/hellogo_fares/read.rs
@@ -19,7 +19,7 @@ use crate::{
     minidom_utils::{TryAttribute, TryOnlyChild},
     model::Collections,
     netex_utils,
-    netex_utils::FrameType,
+    netex_utils::{FrameType, Frames},
     objects::*,
     AddPrefix, Result,
 };
@@ -28,7 +28,7 @@ use log::{info, warn};
 use minidom::Element;
 use rust_decimal::Decimal;
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::BTreeSet,
     convert::{From, TryFrom},
     fs,
     io::Read,
@@ -123,7 +123,7 @@ fn get_prefix(collections: &Collections) -> Option<String> {
         })
 }
 
-fn get_unit_price_frame<'a>(frames: &'a HashMap<FrameType, Vec<&Element>>) -> Result<&'a Element> {
+fn get_unit_price_frame<'a>(frames: &'a Frames<'a>) -> Result<&'a Element> {
     if let Some(fare_frames) = frames.get(&FrameType::Fare) {
         let mut iterator = fare_frames.iter().filter(|fare_frame| {
             utils::get_fare_frame_type(fare_frame)
@@ -463,6 +463,7 @@ mod tests {
 
     mod unit_price_frame {
         use super::*;
+        use std::collections::HashMap;
 
         #[test]
         fn has_unit_price_frame() {

--- a/src/hellogo_fares/read.rs
+++ b/src/hellogo_fares/read.rs
@@ -14,11 +14,12 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
-use super::{utils, utils::FrameType};
+use super::{utils, utils::FareFrameType};
 use crate::{
     minidom_utils::{TryAttribute, TryOnlyChild},
     model::Collections,
     netex_utils,
+    netex_utils::FrameType,
     objects::*,
     AddPrefix, Result,
 };
@@ -26,11 +27,13 @@ use failure::{bail, format_err};
 use log::{info, warn};
 use minidom::Element;
 use rust_decimal::Decimal;
-use std::collections::BTreeSet;
-use std::convert::{From, TryFrom};
-use std::fs;
-use std::io::Read;
-use std::path::Path;
+use std::{
+    collections::{BTreeSet, HashMap},
+    convert::{From, TryFrom},
+    fs,
+    io::Read,
+    path::Path,
+};
 use zip::read::ZipArchive;
 
 impl TryFrom<&Element> for Ticket {
@@ -118,6 +121,27 @@ fn get_prefix(collections: &Collections) -> Option<String> {
                 .find(':')
                 .map(|index| contributor_id[..index].to_string())
         })
+}
+
+fn get_unit_price_frame<'a>(frames: &'a HashMap<FrameType, Vec<&Element>>) -> Result<&'a Element> {
+    if let Some(fare_frames) = frames.get(&FrameType::Fare) {
+        let mut iterator = fare_frames.iter().filter(|fare_frame| {
+            utils::get_fare_frame_type(fare_frame)
+                .map(|fare_frame_type| fare_frame_type == FareFrameType::UnitPrice)
+                .unwrap_or(false)
+        });
+        if let Some(ref unit_price_frame) = iterator.next() {
+            if iterator.next().is_none() {
+                Ok(unit_price_frame)
+            } else {
+                bail!("Failed to find a unique 'UnitPrice' fare frame in the Netex file")
+            }
+        } else {
+            bail!("Failed to find a 'UnitPrice' fare frame in the Netex file")
+        }
+    } else {
+        bail!("Failed to find a fare frame")
+    }
 }
 
 fn calculate_direct_price(distance_matrix_element: &Element) -> Result<Decimal> {
@@ -280,90 +304,88 @@ fn load_netex_fares(collections: &mut Collections, root: &Element) -> Result<()>
     let prefix_with_colon = get_prefix(&collections)
         .map(|prefix| prefix + ":")
         .unwrap_or_else(String::new);
-    let frames = utils::get_fare_frames(root)?;
-    let unit_price_frame = utils::get_only_frame(&frames, FrameType::UnitPrice)?;
-    let service_frame = utils::get_only_frame(&frames, FrameType::Service)?;
-    let resource_frame = utils::get_only_frame(&frames, FrameType::Resource)?;
+    let frames = netex_utils::parse_frames_by_type(
+        root.try_only_child("dataObjects")?
+            .try_only_child("CompositeFrame")?
+            .try_only_child("frames")?,
+    )?;
+    let unit_price_frame = get_unit_price_frame(&frames)?;
+    let service_frame = netex_utils::get_only_frame(&frames, FrameType::Service)?;
+    let resource_frame = netex_utils::get_only_frame(&frames, FrameType::Resource)?;
     let unit_price = utils::get_unit_price(unit_price_frame)?;
     let validity = utils::get_validity(resource_frame)?;
-    for frame_type in &[FrameType::DistanceMatrix, FrameType::DirectPriceMatrix] {
-        if let Some(fare_frames) = frames.get(frame_type) {
-            for fare_frame in fare_frames {
-                let line_id = get_line_id(fare_frame, service_frame)?;
-                let line = if let Some(line) = collections
-                    .lines
-                    .get(&format!("{}{}", &prefix_with_colon, line_id))
-                {
-                    line
-                } else {
-                    warn!("Failed to find line ID '{}' in the existing NTFS", line_id);
-                    continue;
-                };
-                let boarding_fee: Decimal =
-                    netex_utils::get_value_in_keylist(fare_frame, "EntranceRateWrtCurrency")?;
-                let rounding_rule: Decimal =
-                    netex_utils::get_value_in_keylist(fare_frame, "RoundingWrtCurrencyRule")?;
-                let rounding_rule = rounding_rule.normalize().scale();
-                let currency = utils::get_currency(fare_frame)?;
-                let distance_matrix_elements = utils::get_distance_matrix_elements(fare_frame)?;
-                for distance_matrix_element in distance_matrix_elements {
-                    let mut ticket = Ticket::try_from(distance_matrix_element)?;
-                    let price = match frame_type {
-                        FrameType::DirectPriceMatrix => {
-                            boarding_fee + calculate_direct_price(distance_matrix_element)?
-                        }
-                        FrameType::DistanceMatrix => {
-                            let distance: Decimal = get_distance(distance_matrix_element)?.into();
-                            boarding_fee + unit_price * distance
-                        }
-                        _ => continue,
-                    };
-                    let price = price.round_dp_with_strategy(
-                        rounding_rule,
-                        rust_decimal::RoundingStrategy::RoundHalfUp,
-                    );
-                    let mut ticket_price = TicketPrice::try_from((
-                        ticket.id.clone(),
-                        price,
-                        currency.clone(),
-                        validity,
-                    ))?;
-                    let mut ticket_use = TicketUse::from(ticket.id.clone());
-                    let mut ticket_use_perimeter =
-                        TicketUsePerimeter::from((ticket_use.id.clone(), line.id.clone()));
-                    let origin_destinations = get_origin_destinations(
-                        &*collections,
-                        service_frame,
-                        distance_matrix_element,
-                        &prefix_with_colon,
-                    )?;
-                    if !origin_destinations.is_empty() {
-                        for origin_destination in origin_destinations {
-                            let mut ticket_use_restriction = TicketUseRestriction::from((
-                                ticket_use.id.clone(),
-                                origin_destination,
-                            ));
-                            // `use_origin` and `use_destination` are already
-                            // prefixed so we can't use the AddPrefix trait here
-                            ticket_use_restriction.ticket_use_id =
-                                prefix_with_colon.clone() + &ticket_use_restriction.ticket_use_id;
-                            collections
-                                .ticket_use_restrictions
-                                .push(ticket_use_restriction);
-                        }
-                        ticket.add_prefix(&prefix_with_colon);
-                        collections.tickets.push(ticket)?;
-                        ticket_use.add_prefix(&prefix_with_colon);
-                        collections.ticket_uses.push(ticket_use)?;
-                        ticket_price.add_prefix(&prefix_with_colon);
-                        collections.ticket_prices.push(ticket_price);
-                        // `object_id` is already prefixed so we can't use the
-                        // AddPrefix trait here
-                        ticket_use_perimeter.ticket_use_id =
-                            prefix_with_colon.clone() + &ticket_use_perimeter.ticket_use_id;
-                        collections.ticket_use_perimeters.push(ticket_use_perimeter);
-                    }
+    for fare_frame in frames.get(&FrameType::Fare).unwrap_or(&vec![]) {
+        let fare_frame_type = utils::get_fare_frame_type(fare_frame)?;
+        if fare_frame_type != FareFrameType::DirectPriceMatrix
+            && fare_frame_type != FareFrameType::DistanceMatrix
+        {
+            continue;
+        }
+        let line_id = get_line_id(fare_frame, service_frame)?;
+        let line = if let Some(line) = collections
+            .lines
+            .get(&format!("{}{}", &prefix_with_colon, line_id))
+        {
+            line
+        } else {
+            warn!("Failed to find line ID '{}' in the existing NTFS", line_id);
+            continue;
+        };
+        let boarding_fee: Decimal =
+            netex_utils::get_value_in_keylist(fare_frame, "EntranceRateWrtCurrency")?;
+        let rounding_rule: Decimal =
+            netex_utils::get_value_in_keylist(fare_frame, "RoundingWrtCurrencyRule")?;
+        let rounding_rule = rounding_rule.normalize().scale();
+        let currency = utils::get_currency(fare_frame)?;
+        let distance_matrix_elements = utils::get_distance_matrix_elements(fare_frame)?;
+        for distance_matrix_element in distance_matrix_elements {
+            let mut ticket = Ticket::try_from(distance_matrix_element)?;
+            let price = match fare_frame_type {
+                FareFrameType::DirectPriceMatrix => {
+                    boarding_fee + calculate_direct_price(distance_matrix_element)?
                 }
+                FareFrameType::DistanceMatrix => {
+                    let distance: Decimal = get_distance(distance_matrix_element)?.into();
+                    boarding_fee + unit_price * distance
+                }
+                _ => continue,
+            };
+            let price = price
+                .round_dp_with_strategy(rounding_rule, rust_decimal::RoundingStrategy::RoundHalfUp);
+            let mut ticket_price =
+                TicketPrice::try_from((ticket.id.clone(), price, currency.clone(), validity))?;
+            let mut ticket_use = TicketUse::from(ticket.id.clone());
+            let mut ticket_use_perimeter =
+                TicketUsePerimeter::from((ticket_use.id.clone(), line.id.clone()));
+            let origin_destinations = get_origin_destinations(
+                &*collections,
+                service_frame,
+                distance_matrix_element,
+                &prefix_with_colon,
+            )?;
+            if !origin_destinations.is_empty() {
+                for origin_destination in origin_destinations {
+                    let mut ticket_use_restriction =
+                        TicketUseRestriction::from((ticket_use.id.clone(), origin_destination));
+                    // `use_origin` and `use_destination` are already
+                    // prefixed so we can't use the AddPrefix trait here
+                    ticket_use_restriction.ticket_use_id =
+                        prefix_with_colon.clone() + &ticket_use_restriction.ticket_use_id;
+                    collections
+                        .ticket_use_restrictions
+                        .push(ticket_use_restriction);
+                }
+                ticket.add_prefix(&prefix_with_colon);
+                collections.tickets.push(ticket)?;
+                ticket_use.add_prefix(&prefix_with_colon);
+                collections.ticket_uses.push(ticket_use)?;
+                ticket_price.add_prefix(&prefix_with_colon);
+                collections.ticket_prices.push(ticket_price);
+                // `object_id` is already prefixed so we can't use the
+                // AddPrefix trait here
+                ticket_use_perimeter.ticket_use_id =
+                    prefix_with_colon.clone() + &ticket_use_perimeter.ticket_use_id;
+                collections.ticket_use_perimeters.push(ticket_use_perimeter);
             }
         }
     }
@@ -413,10 +435,10 @@ pub fn enrich_with_hellogo_fares<P: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     mod prefix {
-        use super::super::get_prefix;
-        use crate::model::Collections;
-        use crate::objects::Contributor;
+        use super::*;
         use pretty_assertions::assert_eq;
 
         #[test]
@@ -439,11 +461,82 @@ mod tests {
         }
     }
 
+    mod unit_price_frame {
+        use super::*;
+
+        #[test]
+        fn has_unit_price_frame() {
+            let xml = r#"<root>
+                    <fareStructures>
+                        <FareStructure>
+                            <KeyList>
+                                <KeyValue>
+                                    <Key>FareStructureType</Key>
+                                    <Value>UnitPrice</Value>
+                                </KeyValue>
+                            </KeyList>
+                        </FareStructure>
+                    </fareStructures>
+                </root>"#;
+            let unit_price_frame: Element = xml.parse().unwrap();
+            let mut frames = HashMap::new();
+            frames.insert(FrameType::Fare, vec![&unit_price_frame]);
+            let unit_price_frame = get_unit_price_frame(&frames);
+            assert!(unit_price_frame.is_ok())
+        }
+
+        #[test]
+        #[should_panic = "Failed to find a fare frame"]
+        fn no_fare_frame() {
+            get_unit_price_frame(&HashMap::new()).unwrap();
+        }
+
+        #[test]
+        #[should_panic = "Failed to find a \\'UnitPrice\\' fare frame in the Netex file"]
+        fn no_unit_price_fare_frame() {
+            let xml = r#"<root>
+                    <fareStructures>
+                        <FareStructure>
+                            <KeyList>
+                                <KeyValue>
+                                    <Key>FareStructureType</Key>
+                                    <Value>DistanceMatrix</Value>
+                                </KeyValue>
+                            </KeyList>
+                        </FareStructure>
+                    </fareStructures>
+                </root>"#;
+            let unit_price_frame: Element = xml.parse().unwrap();
+            let mut frames = HashMap::new();
+            frames.insert(FrameType::Fare, vec![&unit_price_frame]);
+            get_unit_price_frame(&frames).unwrap();
+        }
+
+        #[test]
+        #[should_panic = "Failed to find a unique \\'UnitPrice\\' fare frame in the Netex file"]
+        fn multiple_unit_price_fare_frame() {
+            let xml = r#"<root>
+                    <fareStructures>
+                        <FareStructure>
+                            <KeyList>
+                                <KeyValue>
+                                    <Key>FareStructureType</Key>
+                                    <Value>UnitPrice</Value>
+                                </KeyValue>
+                            </KeyList>
+                        </FareStructure>
+                    </fareStructures>
+                </root>"#;
+            let unit_price_frame: Element = xml.parse().unwrap();
+            let mut frames = HashMap::new();
+            frames.insert(FrameType::Fare, vec![&unit_price_frame, &unit_price_frame]);
+            get_unit_price_frame(&frames).unwrap();
+        }
+    }
+
     mod ticket {
-        use crate::objects::Ticket;
-        use minidom::Element;
+        use super::*;
         use pretty_assertions::assert_eq;
-        use std::convert::TryFrom;
 
         #[test]
         fn extract_ticket() {
@@ -477,11 +570,10 @@ mod tests {
     }
 
     mod ticket_price {
-        use crate::objects::TicketPrice;
+        use super::*;
         use chrono::NaiveDate;
         use pretty_assertions::assert_eq;
         use rust_decimal_macros::dec;
-        use std::convert::TryFrom;
 
         #[test]
         fn valid_ticket_price() {
@@ -514,9 +606,8 @@ mod tests {
     }
 
     mod ticket_use {
-        use crate::objects::TicketUse;
+        use super::*;
         use pretty_assertions::assert_eq;
-        use std::convert::From;
 
         #[test]
         fn valid_ticket_use() {
@@ -531,9 +622,8 @@ mod tests {
     }
 
     mod ticket_use_perimeter {
-        use crate::objects::{ObjectType, PerimeterAction, TicketUsePerimeter};
+        use super::*;
         use pretty_assertions::assert_eq;
-        use std::convert::From;
 
         #[test]
         fn valid_ticket_use() {
@@ -554,9 +644,8 @@ mod tests {
     }
 
     mod ticket_use_restriction {
-        use crate::objects::{RestrictionType, TicketUseRestriction};
+        use super::*;
         use pretty_assertions::assert_eq;
-        use std::convert::From;
 
         #[test]
         fn valid_ticket_use() {
@@ -585,8 +674,7 @@ mod tests {
     }
 
     mod direct_price {
-        use super::super::calculate_direct_price;
-        use minidom::Element;
+        use super::*;
         use pretty_assertions::assert_eq;
         use rust_decimal_macros::dec;
 
@@ -644,8 +732,7 @@ mod tests {
     }
 
     mod distance {
-        use super::super::get_distance;
-        use minidom::Element;
+        use super::*;
         use pretty_assertions::assert_eq;
 
         #[test]
@@ -670,8 +757,7 @@ mod tests {
     }
 
     mod line_id {
-        use super::super::get_line_id;
-        use minidom::Element;
+        use super::*;
         use pretty_assertions::assert_eq;
 
         const SERVICE_XML: &'static str = r#"<ServiceFrame>
@@ -821,11 +907,8 @@ mod tests {
     }
 
     mod origin_destination {
-        use super::super::get_origin_destinations;
-        use crate::{model::Collections, objects::*};
-        use minidom::Element;
+        use super::*;
         use pretty_assertions::assert_eq;
-        use std::default::Default;
 
         const PREFIX_WITH_COLON: &'static str = "NTM:";
 

--- a/src/netex_idf/lines.rs
+++ b/src/netex_idf/lines.rs
@@ -19,6 +19,8 @@ use super::EUROPE_PARIS_TIMEZONE;
 use crate::{
     minidom_utils::{TryAttribute, TryOnlyChild},
     model::Collections,
+    netex_utils,
+    netex_utils::FrameType,
     objects::{CommercialMode, Company, Line, Network, PhysicalMode},
     Result,
 };
@@ -44,17 +46,12 @@ impl_id!(LineNetexIDF);
 type MapLineNetwork = HashMap<String, String>;
 
 fn load_netex_lines(
-    elem: &Element,
+    frames: &HashMap<FrameType, Vec<&Element>>,
     map_line_network: &MapLineNetwork,
     companies: &CollectionWithId<Company>,
 ) -> Result<CollectionWithId<LineNetexIDF>> {
     let mut lines_netex_idf = CollectionWithId::default();
-    for frame in elem
-        .try_only_child("dataObjects")?
-        .try_only_child("CompositeFrame")?
-        .try_only_child("frames")?
-        .children()
-    {
+    for frame in frames.get(&FrameType::Service).unwrap_or(&vec![]) {
         if let Ok(lines_node) = frame.try_only_child("lines") {
             for line in lines_node.children().filter(|e| e.name() == "Line") {
                 let id = line.try_attribute("id")?;
@@ -116,7 +113,7 @@ fn make_lines(lines_netex_idf: &CollectionWithId<LineNetexIDF>) -> Result<Collec
 }
 
 fn make_networks_companies(
-    elem: &Element,
+    frames: &HashMap<FrameType, Vec<&Element>>,
 ) -> Result<(
     CollectionWithId<Network>,
     CollectionWithId<Company>,
@@ -125,12 +122,7 @@ fn make_networks_companies(
     let mut networks = CollectionWithId::default();
     let mut companies = CollectionWithId::default();
     let mut map_line_network: MapLineNetwork = HashMap::new();
-    for frame in elem
-        .try_only_child("dataObjects")?
-        .try_only_child("CompositeFrame")?
-        .try_only_child("frames")?
-        .children()
-    {
+    for frame in frames.get(&FrameType::Service).unwrap_or(&vec![]) {
         for network in frame.children().filter(|e| e.name() == "Network") {
             let id = network.try_attribute("id")?;
             let name = network.try_only_child("Name")?.text().parse()?;
@@ -151,6 +143,8 @@ fn make_networks_companies(
                     .insert(line_ref.try_attribute("ref")?, network.try_attribute("id")?);
             }
         }
+    }
+    for frame in frames.get(&FrameType::Resource).unwrap_or(&vec![]) {
         if let Ok(organisations) = frame.try_only_child("organisations") {
             for operator in organisations.children().filter(|e| e.name() == "Operator") {
                 let id = operator.try_attribute("id")?;
@@ -210,9 +204,14 @@ pub fn from_path(
     let mut file_content = String::new();
     file.read_to_string(&mut file_content)?;
 
-    let lines_netex_idf = if let Ok(elem) = file_content.parse::<Element>() {
-        let (networks, companies, map_line_network) = make_networks_companies(&elem)?;
-        let lines_netex_idf = load_netex_lines(&elem, &map_line_network, &companies)?;
+    let lines_netex_idf = if let Ok(root) = file_content.parse::<Element>() {
+        let frames = netex_utils::parse_frames_by_type(
+            root.try_only_child("dataObjects")?
+                .try_only_child("CompositeFrame")?
+                .try_only_child("frames")?,
+        )?;
+        let (networks, companies, map_line_network) = make_networks_companies(&frames)?;
+        let lines_netex_idf = load_netex_lines(&frames, &map_line_network, &companies)?;
         let lines = make_lines(&lines_netex_idf)?;
         let (physical_modes, commercial_modes) =
             make_physical_and_commercial_modes(&lines_netex_idf)?;
@@ -237,10 +236,6 @@ mod tests {
         // Test several networks in the same frame, or in several frames
         // Same thing for operators (= companies)
         let xml = r#"
-<root>
-   <dataObjects>
-      <CompositeFrame id="FR100:CompositeFrame:NETEX_IDF-20181108T153214Z:LOC" version="1.8" dataSourceRef="FR100-OFFRE_AUTO">
-         <frames>
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:119">
                <Network version="any" changed="2009-12-02T00:00:00Z" id="STIF:CODIFLIGNE:PTNetwork:119">
                   <Name>VEOLIA RAMBOUILLET</Name>
@@ -255,7 +250,9 @@ mod tests {
                      <LineRef ref="STIF:CODIFLIGNE:Line:C00165"/>
                   </members>
                </Network>
-            </ServiceFrame>
+            </ServiceFrame>"#;
+        let service_frame_networks_1: Element = xml.parse().unwrap();
+        let xml = r#"
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:121">
                <Network version="any" changed="2009-12-02T00:00:00Z" id="STIF:CODIFLIGNE:PTNetwork:121">
                   <Name>VEOLIA RAMBOUILLET 3</Name>
@@ -263,7 +260,9 @@ mod tests {
                      <LineRef ref="STIF:CODIFLIGNE:Line:C00166"/>
                   </members>
                </Network>
-            </ServiceFrame>
+            </ServiceFrame>"#;
+        let service_frame_networks_2: Element = xml.parse().unwrap();
+        let xml = r#"
             <ResourceFrame version="any" id="STIF:CODIFLIGNE:ResourceFrame:1">
                <organisations>
                   <Operator version="any" id="STIF:CODIFLIGNE:Operator:013">
@@ -273,20 +272,30 @@ mod tests {
                      <Name>TRANSDEV IDF RAMBOUILLET 2</Name>
                   </Operator>
                </organisations>
-            </ResourceFrame>
+            </ResourceFrame>"#;
+        let resource_frame_organisations_1: Element = xml.parse().unwrap();
+        let xml = r#"
             <ResourceFrame version="any" id="STIF:CODIFLIGNE:ResourceFrame:2">
                <organisations>
                   <Operator version="any" id="STIF:CODIFLIGNE:Operator:015">
                      <Name>TRANSDEV IDF RAMBOUILLET 3</Name>
                   </Operator>
                </organisations>
-            </ResourceFrame>
-         </frames>
-      </CompositeFrame>
-   </dataObjects>
-</root>"#;
-        let root: Element = xml.parse().unwrap();
-        let (networks, companies, _) = make_networks_companies(&root).unwrap();
+            </ResourceFrame>"#;
+        let resource_frame_organisations_2: Element = xml.parse().unwrap();
+        let mut frames = HashMap::new();
+        frames.insert(
+            FrameType::Service,
+            vec![&service_frame_networks_1, &service_frame_networks_2],
+        );
+        frames.insert(
+            FrameType::Resource,
+            vec![
+                &resource_frame_organisations_1,
+                &resource_frame_organisations_2,
+            ],
+        );
+        let (networks, companies, _) = make_networks_companies(&frames).unwrap();
         let networks_names: Vec<_> = networks.values().map(|n| &n.name).collect();
         assert_eq!(
             networks_names,
@@ -310,10 +319,6 @@ mod tests {
     #[test]
     fn test_make_lines() {
         let xml = r#"
-<root>
-   <dataObjects>
-      <CompositeFrame id="FR100:CompositeFrame:NETEX_IDF-20181108T153214Z:LOC" version="1.8" dataSourceRef="FR100-OFFRE_AUTO">
-         <frames>
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:119">
                <Network version="any" changed="2009-12-02T00:00:00Z" id="STIF:CODIFLIGNE:PTNetwork:119">
                   <Name>VEOLIA RAMBOUILLET</Name>
@@ -327,7 +332,9 @@ mod tests {
                      <LineRef ref="STIF:CODIFLIGNE:Line:C00165"/>
                   </members>
                </Network>
-            </ServiceFrame>
+            </ServiceFrame>"#;
+        let service_frame_networks_1: Element = xml.parse().unwrap();
+        let xml = r#"
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:121">
                <Network version="any" changed="2009-12-02T00:00:00Z" id="STIF:CODIFLIGNE:PTNetwork:121">
                   <Name>VEOLIA RAMBOUILLET 3</Name>
@@ -335,7 +342,9 @@ mod tests {
                      <LineRef ref="STIF:CODIFLIGNE:Line:C00166"/>
                   </members>
                </Network>
-            </ServiceFrame>
+            </ServiceFrame>"#;
+        let service_frame_networks_2: Element = xml.parse().unwrap();
+        let xml = r#"
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:lineid">
                <lines>
                   <Line version="any" created="2014-07-16T00:00:00+00:00" changed="2014-07-16T00:00:00+00:00" status="active" id="STIF:CODIFLIGNE:Line:C00164">
@@ -391,21 +400,29 @@ mod tests {
                      <OperatorRef version="any" ref="STIF:CODIFLIGNE:Operator:0133"/>
                   </Line>
                </lines>
-            </ServiceFrame>
+            </ServiceFrame>"#;
+        let service_frame_lines: Element = xml.parse().unwrap();
+        let xml = r#"
             <ResourceFrame version="any" id="STIF:CODIFLIGNE:ResourceFrame:1">
                <organisations>
                   <Operator version="any" id="STIF:CODIFLIGNE:Operator:013">
                      <Name>TRANSDEV IDF RAMBOUILLET</Name>
                   </Operator>
                </organisations>
-            </ResourceFrame>
-         </frames>
-      </CompositeFrame>
-   </dataObjects>
-</root>"#;
-        let root: Element = xml.parse().unwrap();
-        let (_networks, companies, map_line_network) = make_networks_companies(&root).unwrap();
-        let lines_netex_idf = load_netex_lines(&root, &map_line_network, &companies).unwrap();
+            </ResourceFrame>"#;
+        let resource_frame_organisations: Element = xml.parse().unwrap();
+        let mut frames = HashMap::new();
+        frames.insert(
+            FrameType::Service,
+            vec![
+                &service_frame_networks_1,
+                &service_frame_networks_2,
+                &service_frame_lines,
+            ],
+        );
+        frames.insert(FrameType::Resource, vec![&resource_frame_organisations]);
+        let (_networks, companies, map_line_network) = make_networks_companies(&frames).unwrap();
+        let lines_netex_idf = load_netex_lines(&frames, &map_line_network, &companies).unwrap();
         let lines = make_lines(&lines_netex_idf).unwrap();
         let lines_names: Vec<_> = lines.values().map(|l| &l.name).collect();
         // Test explanation
@@ -418,10 +435,6 @@ mod tests {
     #[should_panic(expected = "Unknown mode UNKNOWN found for line STIF:CODIFLIGNE:Line:C00163")]
     fn test_load_netex_lines_unknown_mode() {
         let xml = r#"
-<root>
-   <dataObjects>
-      <CompositeFrame id="FR100:CompositeFrame:NETEX_IDF-20181108T153214Z:LOC" version="1.8" dataSourceRef="FR100-OFFRE_AUTO">
-         <frames>
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:119">
                <Network version="any" changed="2009-12-02T00:00:00Z" id="STIF:CODIFLIGNE:PTNetwork:119">
                   <Name>VEOLIA RAMBOUILLET</Name>
@@ -429,7 +442,9 @@ mod tests {
                      <LineRef ref="STIF:CODIFLIGNE:Line:C00163"/>
                   </members>
                </Network>
-            </ServiceFrame>
+            </ServiceFrame>"#;
+        let service_frame_networks: Element = xml.parse().unwrap();
+        let xml = r#"
             <ServiceFrame version="any" id="STIF:CODIFLIGNE:ServiceFrame:lineid">
                <lines>
                   <Line version="any" created="2014-07-16T00:00:00+00:00" changed="2014-07-16T00:00:00+00:00" status="active" id="STIF:CODIFLIGNE:Line:C00163">
@@ -441,19 +456,24 @@ mod tests {
                   </Line>
                </lines>
             </ServiceFrame>
+"#;
+        let service_frame_lines: Element = xml.parse().unwrap();
+        let xml = r#"
             <ResourceFrame version="any" id="STIF:CODIFLIGNE:ResourceFrame:1">
                <organisations>
                   <Operator version="any" id="STIF:CODIFLIGNE:Operator:013">
                      <Name>TRANSDEV IDF RAMBOUILLET</Name>
                   </Operator>
                </organisations>
-            </ResourceFrame>
-         </frames>
-      </CompositeFrame>
-   </dataObjects>
-</root>"#;
-        let root: Element = xml.parse().unwrap();
-        let (_networks, companies, map_line_network) = make_networks_companies(&root).unwrap();
-        load_netex_lines(&root, &map_line_network, &companies).unwrap();
+            </ResourceFrame>"#;
+        let resource_frame_organisations: Element = xml.parse().unwrap();
+        let mut frames = HashMap::new();
+        frames.insert(
+            FrameType::Service,
+            vec![&service_frame_networks, &service_frame_lines],
+        );
+        frames.insert(FrameType::Resource, vec![&resource_frame_organisations]);
+        let (_networks, companies, map_line_network) = make_networks_companies(&frames).unwrap();
+        load_netex_lines(&frames, &map_line_network, &companies).unwrap();
     }
 }

--- a/src/netex_idf/lines.rs
+++ b/src/netex_idf/lines.rs
@@ -20,7 +20,7 @@ use crate::{
     minidom_utils::{TryAttribute, TryOnlyChild},
     model::Collections,
     netex_utils,
-    netex_utils::FrameType,
+    netex_utils::{FrameType, Frames},
     objects::{CommercialMode, Company, Line, Network, PhysicalMode},
     Result,
 };
@@ -46,7 +46,7 @@ impl_id!(LineNetexIDF);
 type MapLineNetwork = HashMap<String, String>;
 
 fn load_netex_lines(
-    frames: &HashMap<FrameType, Vec<&Element>>,
+    frames: &Frames,
     map_line_network: &MapLineNetwork,
     companies: &CollectionWithId<Company>,
 ) -> Result<CollectionWithId<LineNetexIDF>> {
@@ -113,7 +113,7 @@ fn make_lines(lines_netex_idf: &CollectionWithId<LineNetexIDF>) -> Result<Collec
 }
 
 fn make_networks_companies(
-    frames: &HashMap<FrameType, Vec<&Element>>,
+    frames: &Frames,
 ) -> Result<(
     CollectionWithId<Network>,
     CollectionWithId<Company>,

--- a/src/netex_idf/stops.rs
+++ b/src/netex_idf/stops.rs
@@ -20,7 +20,7 @@ use crate::{
     minidom_utils::{TryAttribute, TryOnlyChild},
     model::Collections,
     netex_utils,
-    netex_utils::FrameType,
+    netex_utils::{FrameType, Frames},
     objects::{Codes, Coord, Equipment, StopArea, StopPoint, StopType},
     Result,
 };
@@ -256,7 +256,7 @@ fn load_stop_points<'a>(
 }
 
 fn load_stops(
-    frames: &HashMap<FrameType, Vec<&Element>>,
+    frames: &Frames,
 ) -> Result<(
     CollectionWithId<StopArea>,
     CollectionWithId<StopPoint>,

--- a/src/netex_utils/mod.rs
+++ b/src/netex_utils/mod.rs
@@ -1,7 +1,72 @@
 use crate::{minidom_utils::TryOnlyChild, Result};
-use failure::{bail, format_err};
+use failure::{bail, format_err, Error};
 use minidom::Element;
-use std::str::FromStr;
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub enum FrameType {
+    General,
+    Resource,
+    Service,
+    Fare,
+}
+
+impl Display for FrameType {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            FrameType::Fare => write!(f, "Fare"),
+            FrameType::General => write!(f, "General"),
+            FrameType::Resource => write!(f, "Resource"),
+            FrameType::Service => write!(f, "Service"),
+        }
+    }
+}
+
+impl FromStr for FrameType {
+    type Err = Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "FareFrame" => Ok(FrameType::Fare),
+            "GeneralFrame" => Ok(FrameType::General),
+            "ResourceFrame" => Ok(FrameType::Resource),
+            "ServiceFrame" => Ok(FrameType::Service),
+            _ => bail!("Failed to convert '{}' into a FrameType", s),
+        }
+    }
+}
+
+pub fn parse_frames_by_type<'a>(
+    frames: &'a Element,
+) -> Result<HashMap<FrameType, Vec<&'a Element>>> {
+    frames
+        .children()
+        .try_fold(HashMap::new(), |mut map, frame| {
+            let frame_type: FrameType = frame.name().parse()?;
+            map.entry(frame_type).or_insert_with(Vec::new).push(frame);
+            Ok(map)
+        })
+}
+
+pub fn get_only_frame<'a>(
+    frames: &'a HashMap<FrameType, Vec<&'a Element>>,
+    frame_type: FrameType,
+) -> Result<&'a Element> {
+    let frame = frames
+        .get(&frame_type)
+        .ok_or_else(|| format_err!("Failed to find a '{}' frame in the Netex file", frame_type))?;
+    if frame.len() == 1 {
+        Ok(frame[0])
+    } else {
+        bail!(
+            "Failed to find a unique '{}' frame in the Netex file",
+            frame_type
+        )
+    }
+}
 
 pub fn get_value_in_keylist<F>(element: &Element, key: &str) -> Result<F>
 where
@@ -32,6 +97,83 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod frame_type {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn parse_frame_type() {
+            let frame_type: FrameType = "ServiceFrame".parse().unwrap();
+            assert_eq!(frame_type, FrameType::Service);
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to convert \\'NotAFrameType\\' into a FrameType")]
+        fn parse_invalid_frame_type() {
+            "NotAFrameType".parse::<FrameType>().unwrap();
+        }
+    }
+
+    mod parse_frames_by_type {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn some_frame() {
+            let xml = r#"<root>
+                    <FareFrame />
+                    <ServiceFrame />
+                    <FareFrame />
+                </root>"#;
+            let root: Element = xml.parse().unwrap();
+            let frames = parse_frames_by_type(&root).unwrap();
+            assert_eq!(frames.keys().count(), 2);
+            assert_eq!(frames.get(&FrameType::Service).unwrap().len(), 1);
+            assert_eq!(frames.get(&FrameType::Fare).unwrap().len(), 2);
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to convert \\'UnknownFrame\\' into a FrameType")]
+        fn unknown_frame() {
+            let xml = r#"<root>
+                    <UnknownFrame />
+                </root>"#;
+            let root: Element = xml.parse().unwrap();
+            parse_frames_by_type(&root).unwrap();
+        }
+    }
+
+    mod get_only_frame {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn one_frame() {
+            let mut frames = HashMap::new();
+            let frame: Element = r#"<frame xmlns="test" />"#.parse().unwrap();
+            frames.insert(FrameType::Resource, vec![&frame]);
+            let resource_frame = get_only_frame(&frames, FrameType::Resource).unwrap();
+            assert_eq!(resource_frame.name(), "frame");
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to find a \\'Service\\' frame in the Netex file")]
+        fn no_frame() {
+            let frames = HashMap::new();
+            get_only_frame(&frames, FrameType::Service).unwrap();
+        }
+
+        #[test]
+        #[should_panic(expected = "Failed to find a unique \\'Resource\\' frame in the Netex file")]
+        fn multiple_frames() {
+            let mut frames = HashMap::new();
+            let frame: Element = r#"<frame xmlns="test" />"#.parse().unwrap();
+            frames.insert(FrameType::Resource, vec![&frame, &frame]);
+            get_only_frame(&frames, FrameType::Resource).unwrap();
+        }
+    }
+
     mod value_in_keylist {
         use super::*;
         use pretty_assertions::assert_eq;

--- a/src/netex_utils/mod.rs
+++ b/src/netex_utils/mod.rs
@@ -14,6 +14,7 @@ pub enum FrameType {
     Service,
     Fare,
 }
+pub type Frames<'a> = HashMap<FrameType, Vec<&'a Element>>;
 
 impl Display for FrameType {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -39,9 +40,7 @@ impl FromStr for FrameType {
     }
 }
 
-pub fn parse_frames_by_type<'a>(
-    frames: &'a Element,
-) -> Result<HashMap<FrameType, Vec<&'a Element>>> {
+pub fn parse_frames_by_type<'a>(frames: &'a Element) -> Result<Frames<'a>> {
     frames
         .children()
         .try_fold(HashMap::new(), |mut map, frame| {
@@ -51,10 +50,7 @@ pub fn parse_frames_by_type<'a>(
         })
 }
 
-pub fn get_only_frame<'a>(
-    frames: &'a HashMap<FrameType, Vec<&'a Element>>,
-    frame_type: FrameType,
-) -> Result<&'a Element> {
+pub fn get_only_frame<'a>(frames: &'a Frames<'a>, frame_type: FrameType) -> Result<&'a Element> {
     let frame = frames
         .get(&frame_type)
         .ok_or_else(|| format_err!("Failed to find a '{}' frame in the Netex file", frame_type))?;

--- a/tests/enrich_with_hellogo_fares.rs
+++ b/tests/enrich_with_hellogo_fares.rs
@@ -78,7 +78,7 @@ fn test_read_global_without_prefix() {
 }
 
 #[test]
-#[should_panic(expected = "Failed to find a \\'UnitPrice\\' frame in the Netex file")]
+#[should_panic(expected = "Failed to find a \\'UnitPrice\\' fare frame in the Netex file")]
 fn test_read_ko_no_unit_price() {
     let objects = transit_model::ntfs::read(Path::new(
         "./tests/fixtures/enrich-with-hellogo-fares/input/ntfs_with_prefix",
@@ -93,7 +93,7 @@ fn test_read_ko_no_unit_price() {
 }
 
 #[test]
-#[should_panic(expected = "Failed to find a unique \\'UnitPrice\\' frame in the Netex file")]
+#[should_panic(expected = "Failed to find a unique \\'UnitPrice\\' fare frame in the Netex file")]
 fn test_read_ko_several_unit_prices() {
     let objects = transit_model::ntfs::read(Path::new(
         "./tests/fixtures/enrich-with-hellogo-fares/input/ntfs_with_prefix",


### PR DESCRIPTION
This PR is relatively big so we could do a live peer review so I can guide some of you to review it. Below is some details about what is done.

In HelloGo Fares, we had some utilities to parse Netex frames (`ServiceFrame`, `ResourceFrame`, `FareFrame`), classify them and use them. We have the same need in Netex IDF: this PR is mostly moving these utilities inside `netex_utils/mod.rs` and use these exposed methods in `netex_idf` parsing... with some adjustments :wink: 