### PR TITLE
[fix] merge-stop-areas: update route's destination_id

### DIFF
--- a/src/merge_stop_areas.rs
+++ b/src/merge_stop_areas.rs
@@ -183,6 +183,7 @@ fn apply_rules(
     let mut geometries_updated = collections.geometries.take();
     let mut lines_updated = collections.lines.take();
     let mut ticket_use_restrictions_updated = collections.ticket_use_restrictions.take();
+    let mut routes_updated = collections.routes.take();
     let mut stop_areas_to_remove: HashSet<String> = HashSet::new();
     let mut stop_area_ids = collections
         .stop_areas
@@ -225,6 +226,13 @@ fn apply_rules(
                 }
             }
         }
+        for route in &mut routes_updated {
+            if let Some(ref mut destination_id) = route.destination_id {
+                if rule.to_merge_stop_area_ids.contains(&destination_id) {
+                    *destination_id = rule.master_stop_area_id.clone();
+                }
+            }
+        }
         let mut comment_links = CommentLinksT::default();
         let mut object_codes = KeysValues::default();
         let mut object_properties = KeysValues::default();
@@ -255,6 +263,7 @@ fn apply_rules(
     collections.stop_areas = CollectionWithId::new(stop_areas_updated)?;
     collections.lines = CollectionWithId::new(lines_updated)?;
     collections.ticket_use_restrictions = Collection::new(ticket_use_restrictions_updated);
+    collections.routes = CollectionWithId::new(routes_updated)?;
     Ok(collections)
 }
 

--- a/tests/fixtures/merge-stop-areas/output/routes.txt
+++ b/tests/fixtures/merge-stop-areas/output/routes.txt
@@ -1,0 +1,3 @@
+route_id,route_name,direction_type,line_id,geometry_id,destination_id
+route:01,Hôtels - Hôtels,,line:01,,SA:01
+route:02,Hôtels - Hôtels,,line:01,,SA:01

--- a/tests/merge_stop_areas.rs
+++ b/tests/merge_stop_areas.rs
@@ -51,6 +51,7 @@ fn test_merge_stop_areas_multi_steps() {
                 "stops.txt",
                 "ticket_use_restrictions.txt",
                 "report.json",
+                "routes.txt",
             ]),
             "./tests/fixtures/merge-stop-areas/output/",
         );


### PR DESCRIPTION
with `merge-stop-areas`, some stop areas are removed but routes referencing those stop areas in `destination_id` were not updated