### PR TITLE
Integrate parsing errors into the specification

### DIFF
--- a/src/documentation/gtfs_to_ntfs_specs.md
+++ b/src/documentation/gtfs_to_ntfs_specs.md
@@ -4,11 +4,18 @@
 This document aims to describe how the [GTFS format](https://developers.google.com/transit/gtfs/reference) is read in the Navitia Transit Model. To improve readability of this document, the specification will describe the transformation of a GTFS feed into a [NTFS feed](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md) (which is a bunch of csv files accordingly to the memory Navitia Transit Model).
 
 ## Introduction
+If at any time of the conversion, the GTFS is not conform to the [GTFS
+specification](https://developers.google.com/transit/gtfs/reference), the
+conversion should stop immediately with an error, unless otherwise specified.
+
+At the end of the conversion, a sanitizing operation is started on the final
+model. See [sanitizer.md](sanitizer.md) for more information.
+
 ### Prepending data
 The NTFS format introduce 2 objects to enable the manipulation of several datasets : contributors and datasets. Those two objects are not described here. The construction of NTFS objects IDs requires, for uniqueness purpose, that a unique prefix (specified for each source of data) needs to be included in every object's id.
 
 In the following chapters, identifiers may be prepend with this _prefix_ using this pattern : **\<prefix>:<object\_id>**.
-The use of this specific pattern is shown explicitly using the value **ID** in the column _Constraint_ in the tables bellow.
+The use of this specific pattern is shown explicitly using the value **ID** in the column _Constraint_ in the tables below.
 
 ## Mapping of objects between GTFS and NTFS
 | GTFS object | NTFS object(s) |
@@ -21,20 +28,22 @@ The use of this specific pattern is shown explicitly using the value **ID** in t
 
 ## Detailed mapping of objects
 ### Reading agency.txt
-The field "agency_id" may not be provided in the GTFS as it's an optionnal field.
+The field "agency_id" may not be provided in the GTFS as it's an optional field.
 * If there is only one agency, the "agency_id" is considered to be "1".
 * If there are several agencies, the program will raise an exception as it won't be able to choose the right agency for the routes.
 
 #### Loading Networks
+If 2 networks with the same ID are specified, the conversion should stop
+immediately with an error.
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
 | networks.txt | network_id | ID | agency.txt | agency_id | See above when not specified |
 | networks.txt | network_name | Required | agency.txt | agency_name |  |
-| networks.txt | network_url | Optionnal | agency.txt | agency_url |  |
-| networks.txt | network_timezone | Optionnal | agency.txt | agency_timezone | |
-| networks.txt | network_lang | Optionnal | agency.txt | agency_lang |  |
-| networks.txt | network_phone | Optionnal | agency.txt | agency_phone |  |
+| networks.txt | network_url | Optional | agency.txt | agency_url |  |
+| networks.txt | network_timezone | Optional | agency.txt | agency_timezone | |
+| networks.txt | network_lang | Optional | agency.txt | agency_lang |  |
+| networks.txt | network_phone | Optional | agency.txt | agency_phone |  |
 
 **_"Source" complementary code :_**
 
@@ -46,29 +55,34 @@ A complementary `object_code` is added to each network with the following proper
 
 
 #### Loading Companies
+If 2 companies with the same ID are specified, the conversion should stop
+immediately with an error.
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
 | companies.txt | company_id | ID | agency.txt | agency_id | `1` if the value is not provided (same rule as networks) |
 | companies.txt | company_name | Required | agency.txt | agency_name |  |
-| companies.txt | company_url | Optionnal | agency.txt | agency_lang |  |
-| companies.txt | company_phone | Optionnal | agency.txt | agency_phone |  |
+| companies.txt | company_url | Optional | agency.txt | agency_lang |  |
+| companies.txt | company_phone | Optional | agency.txt | agency_phone |  |
 
 ### Reading stops.txt
 Like the GTFS, the NTFS group stop_points and stop_areas in on file : stops.txt.
+If the stop_points have the same ID, the conversion should stop immediately with
+an error. Likewise for the stop_areas.
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
-| stops.txt | stop_id | ID | stops.txt | stop_id |  |
-| object_codes.txt | object_code | Optionnal | stops.txt | stop_code | This GTFS property is stored as an associated code for this stop. See (2) for complementary properties. |
+| stops.txt | stop_id | ID | stops.txt | stop_id | All slashes `/` will be removed |
+| object_codes.txt | object_code | Optional | stops.txt | stop_code | This GTFS property is stored as an associated code for this stop. See (2) for complementary properties. |
 | stops.txt | stop_name | Required | stops.txt | stop_name |  |
 | stops.txt | stop_lat | Required | stops.txt | stop_lat |  |
 | stops.txt | stop_lon | Required | stops.txt | stop_lon |  |
-| stops.txt | location_type | Optionnal | stops.txt | location_type |  |
-| stops.txt | parent_station | Optionnal | stops.txt | parent_station | (1) |
-| stops.txt | stop_timezone | Optionnal | stops.txt | stop_timezone |  |
-| comments.txt | comment_value | Optionnal | stops.txt | stop_desc | See (3) for additionnal properties |
-| equipments.txt | wheelchair_boarding | Optionnal | stops.txt | wheelchair_boarding | See (4) for detailed info. |
+| stops.txt | location_type | Optional | stops.txt | location_type | If value is not one of `0`, `1`, `2`, `3` or `4`, then set to `0` |
+| stops.txt | parent_station | Optional | stops.txt | parent_station | All
+slashes `/` are removed (1) |
+| stops.txt | stop_timezone | Optional | stops.txt | stop_timezone |  |
+| comments.txt | comment_value | Optional | stops.txt | stop_desc | See (3) for additional properties |
+| equipments.txt | wheelchair_boarding | Optional | stops.txt | wheelchair_boarding | If value is not one of `0`, `1` or `2`, then set to `0`. See (4) for detailed info. |
 
 
 (1) If the `parent_station` field of a stop_point (`location_type` = 0 or empty) is missing or empty, then a stop_area should be created, using the following properties :
@@ -104,7 +118,7 @@ A complementary `object_code` is added to each stop with the following propertie
 
 ### Reading routes.txt
 ##### Mapping of route_type with modes
-The standard values of the `route_type` field are directly mapped to the NTFS modes. [Extended GTFS modes](https://developers.google.com/transit/gtfs/reference/extended-route-types) are read by categories mapping the most prominent mode. A more detailed mapping of the extended modes might be considered in a later version. The priority is used to prioritize the use of a commercial mode when creating a Line grouping routes with different `route_type`s. This priorization follow the [Netex Specification](http://www.normes-donnees-tc.org/wp-content/uploads/2014/05/NF_Profil_NeTEx_pour_les_arrets-_F-_-_v2.pdf) in chapter 6.2.3 (and also indicated in the NTFS Specification).
+The standard values of the `route_type` field are directly mapped to the NTFS modes. [Extended GTFS modes](https://developers.google.com/transit/gtfs/reference/extended-route-types) are read by categories mapping the most prominent mode. The priority is used to prioritize the use of a commercial mode when creating a Line grouping routes with different `route_type`s. This priorization follow the [Netex Specification](http://www.normes-donnees-tc.org/wp-content/uploads/2014/05/NF_Profil_NeTEx_pour_les_arrets-_F-_-_v2.pdf) in chapter 6.2.3 (and also indicated in the NTFS Specification).
 
 | GTFS route_type | NTFS physical_mode ID (1) | NTFS commercial_mode ID (2) | NTFS commercial_mode name | Priority |
 | --- | --- | --- | --- | --- |
@@ -125,17 +139,18 @@ The standard values of the `route_type` field are directly mapped to the NTFS mo
 (2) The commercial_mode ID are standardized when converting from GTFS. This value must not be prefixed.
 
 #### Loading Routes
-A Route is created for each direction of existing trips.
+A Route is created for each direction of existing trips.  If 2 routes with the
+same ID are specified, the conversion should stop immediately with an error.
 _Warning :_ If the GTFS route has no trips, the Navitia Route should NOT be created and a warning should be logged.
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
-| routes.txt | route_id | ID | routes.txt | route_id | postpend a `_R` suffix for the Route grouping trips with `direction_id` = 1 (no suffix for `0` or undefined `direction_id`) |
+| routes.txt | route_id | ID | routes.txt | route_id | append a `_R` suffix for the Route grouping trips with `direction_id` = 1 (no suffix for `0` or undefined `direction_id`) |
 | routes.txt | route_name | Required | routes.txt | route_long_name | if `route_long_name` is empty, use `route_short_name` |
-| routes.txt | direction_type | Optionnal |  |  | (1) |
+| routes.txt | direction_type | Optional |  |  | (1) |
 | routes.txt | line_id | Required |  |  | corresponding `line.id` (see Line construction above) |
-| routes.txt | destination_id | Optionnal |  |  | This field contains a stop_area.id of the most frequent destination of the contained trips (ie. the parent_station of the most frequent last stop of trips) |
-| comments.txt | comment_value | Optionnal | routes.txt | route_desc  | See (2) for additionnal properties |
+| routes.txt | destination_id | Optional |  |  | This field contains a stop_area.id of the most frequent destination of the contained trips (ie. the parent_station of the most frequent last stop of trips) |
+| comments.txt | comment_value | Optional | routes.txt | route_desc  | See (2) for additional properties |
 
 (1) the field `direction_type` contains `backward` when grouping GTFS Trips with `direction_id` = 1, `forward` otherwise
 
@@ -144,23 +159,28 @@ _Warning :_ If the GTFS route has no trips, the Navitia Route should NOT be crea
 * `comment_type` : specify the fixed value "Information"
 
 #### Loading Lines
-A Navitia Line is created to group one or several Navitia Routes when they are created with the same gtfs `agency_id` and the same `route_short_name` (or `route_long_name` if the latter is empty).
-
+A Navitia Line is created to group one or several Navitia Routes when they are
+created with the same gtfs `agency_id` and the same `route_short_name` (or
+`route_long_name` if the latter is empty).  If 2 lines with the same ID are
+specified, the conversion should stop immediately with an error.
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
-| lines.txt | network_id | Required |  |  | This field should contain the `network.id` corresponding to the `agency_id` of the routes. |
+| lines.txt | network_id | Required |  |  | This field should contain the `network.id` corresponding to the `agency_id` of the routes; if no `agency_id` is specified in the route, use the ID of the unique network; if no network or multiple networks are available, the conversion should stop immediately with an error |
 | lines.txt | line_id | ID | routes.txt | route_id | Use the smallest `route_id` of the grouped gtfs Route |
-| lines.txt | line_code | Optionnal | routes.txt | route_short_name |  |
+| lines.txt | line_code | Optional | routes.txt | route_short_name |  |
 | lines.txt | line_name | Required | routes.txt |  | The Navitia `route_name` of the Route with the smallest `route_id` (as a string) is used. |
-| lines.txt | line_color | Optionnal | routes.txt | route_color | if several values are available, a warning is logged and the color of the smallest `route_id` is used |
-| lines.txt | line_text_color | Optionnal | routes.txt | route_text_color | same as line_color |
-| lines.txt | line_sort_order | Optionnal | routes.txt | route_sort_order |  |
+| lines.txt | line_color | Optional | routes.txt | route_color | if several values are available, a warning is logged and the color of the smallest `route_id` is used; if color format is incorrect, the value is dropped |
+| lines.txt | line_text_color | Optional | routes.txt | route_text_color | same as line_color; if color format is incorrect, the value is dropped |
+| lines.txt | line_sort_order | Optional | routes.txt | route_sort_order |  |
 | lines.txt | commercial_mode_id | Required | routes.txt | route_type | See "Mapping of route_type with modes" chapter (1). |
 
 (1) When several GTFS Routes with different `route_type`s are grouped together, the commercial_mode_id with the smallest priority should be used (as specified in chapter "Mapping of route_type with modes").
 
 ### Reading trips.txt
+If 2 trips with the same ID are specified, the conversion should stop
+immediately with an error.
+
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
@@ -173,12 +193,12 @@ A Navitia Line is created to group one or several Navitia Routes when they are c
 | trips.txt | physical_mode_id | Required |  |  | use the `route_type` See ["Mapping of route_type with modes"](#mapping-of-route_type-with-modes) chapter |
 | trips.txt | trip_property_id | Optional | trips.txt |  | (1) |
 | trips.txt | dataset_id | Required |  |  | The `dataset_id` provided (cf. [gtfs2ntfs.md](./gtfs2ntfs.md) ) |
-| trips.txt | geometry_id | Optional | trips.txt | shape_id |  |
+| trips.txt | geometry_id | Optional | trips.txt | shape_id | All slashes `/` are removed |
 
 (1) The `trip_property` object is a complex type with additional properties :
 + `trip_property_id`: should be generated by the reader.
-+ `wheelchair_accessible`: possible values are the same in both GTFS and NTFS
-+ `bike_accepted`: corresponding to the GTFS `bikes_allowed` property. Possible values are the same in both GTFS and NTFS.
++ `wheelchair_accessible`: possible values are the same in both GTFS and NTFS; if value is not one of `0`, `1` or `2`, then set to `0`.
++ `bike_accepted`: corresponding to the GTFS `bikes_allowed` property. Possible values are the same in both GTFS and NTFS; if value is not one of `0`, `1` or `2`, then set to `0`.
 Be careful to only create necessary `trip_properties` and avoid duplicates.
 
 **_"Source" complementary code :_**
@@ -194,15 +214,15 @@ A complementary `object_code` is added to each vehicle journey with the followin
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
-| stop_times.txt | trip_id | Required | stop_times.txt | trip_id |  |
-| stop_times.txt | arrival_time | Optionnal | stop_times.txt | arrival_time | If not specified, see (1) |
-| stop_times.txt | departure_time | Optionnal | stop_times.txt | departure_time | If not specified, see (1) |
-| stop_times.txt | stop_id | Required | stop_times.txt | stop_id |  |
+| stop_times.txt | trip_id | Required | stop_times.txt | trip_id | All slashes `/` are removed; if the corresponding trip doesn't exist, the conversion should stop immediately with an error |
+| stop_times.txt | arrival_time | Optional | stop_times.txt | arrival_time | If not specified, see (1) |
+| stop_times.txt | departure_time | Optional | stop_times.txt | departure_time | If not specified, see (1) |
+| stop_times.txt | stop_id | Required | stop_times.txt | stop_id | If the corresponding stop doesn't exist, the conversion should stop immediately with an error |
 | stop_times.txt | stop_sequence | Required | stop_times.txt | stop_sequence |  |
-| stop_times.txt | stop_headsign | Optionnal | stop_times.txt | stop_headsign |  |
-| stop_times.txt | pickup_type | Optionnal | stop_times.txt | pickup_type |  |
-| stop_times.txt | drop_off_type | Optionnal | stop_times.txt | drop_off_type |  |
-| stop_times.txt | date_time_estimated | Optionnal | stop_times.txt | timepoint | GTFS and NTFS values are inverted. See (2) |
+| stop_times.txt | stop_headsign | Optional | stop_times.txt | stop_headsign |  |
+| stop_times.txt | pickup_type | Optional | stop_times.txt | pickup_type | If invalid unsigned integer, default to `0` |
+| stop_times.txt | drop_off_type | Optional | stop_times.txt | drop_off_type | If invalid unsigned integer, default to `0` |
+| stop_times.txt | date_time_estimated | Optional | stop_times.txt | timepoint | GTFS and NTFS values are inverted. See (2). If invalid unsigned integer, default to `1` |
 
 (1) GTFS `arrival_time` and `departure_time` should contain values.
 * if both of them are empty :
@@ -229,20 +249,25 @@ For exemple :
 * if `timepoint` equals 0 => `date_time_estimated` equals 1
 
 ### Reading transfers.txt
+- If 2 transfers with the same ID are specified, the conversion should stop
+  immediately with an error
+- If a line of the file is not conform to the specification, then the line is
+  ignored
 
 | NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
 | --- | --- | --- | --- | --- | --- |
-| transfers.txt | from_stop_id | Required | transfers.txt | from_stop_id |  |
-| transfers.txt | to_stop_id | Required | transfers.txt | to_stop_id | |
-| transfers.txt | min_transfer_time | Optionnal | transfers.txt | | see (1) |
-| transfers.txt | real_min_transfer_time | Optionnal | transfers.txt | | see (1) |
-| transfers.txt | equipment_id | Optionnal | transfers.txt |  |  |
+| transfers.txt | from_stop_id | Required | transfers.txt | from_stop_id | All slashes `/` are removed; if the `stop_id` doesn't exist in `stops.txt`, the transfer is ignored |
+| transfers.txt | to_stop_id | Required | transfers.txt | to_stop_id | All slashes `/` are removed; if the `stop_id` doesn't exist in `stops.txt`, the transfer is ignored |
+| transfers.txt | min_transfer_time | Optional | transfers.txt | | see (1) |
+| transfers.txt | real_min_transfer_time | Optional | transfers.txt | | see (1) |
+| transfers.txt | equipment_id | Optional | transfers.txt |  |  |
 
-(1) NTFS `min_transfer_time` and `real_min_transfer_time` are calculated as follows.
+(1) NTFS `min_transfer_time` and `real_min_transfer_time` are calculated as
+follows. Note that if value is not one of `0`, `1`, `2` or `3`, then set to `0`.
 
 | GTFS `transfer_type` | NTFS `min_transfer_time` | NTFS `real_min_transfer_time` | Note |
 | --- | --- | --- |--- |
 | 0 | time between 2 stop points | time between 2 stop points + 2 minutes | The time is calculated with the distance as the crow flies and a walking speed of 0.785 m/s. Speed value is lowered because effective transit is not straight |
-| 1 | 0 | 0 |
-| 2 | GTFS `min_transfer_time` | GTFS `min_transfer_time` |
-| 3 | 86400 | 86400 |
+| 1 | 0 | 0 | |
+| 2 | GTFS `min_transfer_time` | GTFS `min_transfer_time` | Log a warning message if the `min_transfer_time` is empty |
+| 3 | 86400 | 86400 | |

--- a/src/documentation/sanitizer.md
+++ b/src/documentation/sanitizer.md
@@ -1,0 +1,51 @@
+# Sanitizer
+
+The sanitizer check for incoherences in the model and also clean up all dangling
+objects (for example, a line which is not referred by any route).  This document
+explains this process in details.
+
+## Incoherences
+This part of the process will check for model incoherences and will raise an
+error if one is found.  The first category is about duplicate identifiers:
+- if 2 datasets have the same identifier
+- if 2 lines have the same identifier
+- if 2 stop points have the same identifier
+- if 2 stop areas have the same identifier
+- if 2 routes have the same identifier
+- if 2 vehicle journeys have the same identifier
+
+The second category is about dangling references:
+- if a transfer refers a stop which doesn't exist (`from_stop_id` and
+  `to_stop_id`)
+- if a vehicle journey refers to a route which doesn't exist
+- if a vehicle journey refers to a commercial mode which doesn't exist
+- if a vehicle journey refers to a dataset which doesn't exist
+- if a vehicle journey refers to a company which doesn't exist
+- if a vehicle journey refers to a calendar which doesn't exist
+- if a line refers to a network which doesn't exist
+- if a line refers to a commercial mode which doesn't exist
+- if a route refers to a line which doesn't exist
+- if a stop point refers to a stop area which doesn't exist
+- if a dataset refers to a contributor which doesn't exist
+
+## Dangling objects
+After multiple processes applied to a NTFS, some objects might not be referenced
+anymore. This part of the process remove all of these objects:
+- datasets which are not referenced
+- contributors which are not referenced
+- companies which are not referenced
+- networks which are not referenced
+- lines which are not referenced
+- routes which are not referenced
+- vehicle journeys which are not referenced
+- stop points which are not referenced
+- stop areas which are not referenced
+- services which doesn't contain any date
+- geometries which are not referenced
+- equipments which are not referenced
+- transfers which are not referenced
+- frequencies which are not referenced
+- physical modes which are not referenced
+- commercial modes which are not referenced
+- trip properties which are not referenced
+- comments which are not referenced


### PR DESCRIPTION
This is a first draft to introduce some of the error management into the specification of the GTFS -> NTFS connector. Below are a few more consideration that might be address as part of this PR or as another PR... to be discussed in this PR.
- there is no specification for the parsing of `shapes.txt`
- there is no specification for the parsing of `frequencies.txt`
- there is no specification for the parsing of `calendar.txt`
- there is no specification for the parsing of `calendar_dates.txt`
- the implementation is parsing a field `local_zone_id` in `stop_times.txt`... but this field doesn't exist in [GTFS specification](https://developers.google.com/transit/gtfs/reference)
- the specification for dataset and contributors is not sufficient (it's only mentioned we need a dataset and a contributor but nothing about the data and information they should contain)
- the conversion of `location_type` in `stops.txt` is incorrect/not specified (there is a mapping, we can't just keep the same integer)
