### PR TITLE
Fix NTFS version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub mod transxchange;
 pub mod vptranslator;
 
 /// Current version of the NTFS format
-pub const NTFS_VERSION: &str = "0.9.3";
+pub const NTFS_VERSION: &str = "0.9.2";
 
 lazy_static::lazy_static! {
     /// Current datetime

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -395,7 +395,7 @@ mod tests {
                     ("feed_end_date".to_string(), "20180131".to_string()),
                     ("feed_publisher_name".to_string(), "Nicaragua".to_string()),
                     ("feed_start_date".to_string(), "20180130".to_string()),
-                    ("ntfs_version".to_string(), "0.9.3".to_string()),
+                    ("ntfs_version".to_string(), "0.9.2".to_string()),
                     ("tartare_platform".to_string(), "dev".to_string()),
                 ],
                 collections

--- a/tests/fixtures/filter_ntfs/output_extract/feed_infos.txt
+++ b/tests/fixtures/filter_ntfs/output_extract/feed_infos.txt
@@ -3,4 +3,4 @@ feed_creation_date,20190403
 feed_creation_time,17:19:00
 feed_end_date,20190106
 feed_start_date,20190101
-ntfs_version,0.9.3
+ntfs_version,0.9.2

--- a/tests/fixtures/filter_ntfs/output_remove/feed_infos.txt
+++ b/tests/fixtures/filter_ntfs/output_remove/feed_infos.txt
@@ -3,4 +3,4 @@ feed_creation_date,20190403
 feed_creation_time,17:19:00
 feed_end_date,20190106
 feed_start_date,20190101
-ntfs_version,0.9.3
+ntfs_version,0.9.2

--- a/tests/fixtures/gtfs2ntfs/minimal/output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/minimal/output/feed_infos.txt
@@ -3,4 +3,4 @@ feed_creation_date,20190403
 feed_creation_time,17:19:00
 feed_end_date,20180106
 feed_start_date,20180101
-ntfs_version,0.9.3
+ntfs_version,0.9.2

--- a/tests/fixtures/gtfs2ntfs/minimal_with_config/output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/minimal_with_config/output/feed_infos.txt
@@ -6,6 +6,6 @@ feed_license,DefaultDatasourceLicense
 feed_license_url,http://www.default-datasource-website.com
 feed_publisher_name,DefaultContributorName
 feed_start_date,20180101
-ntfs_version,0.9.3
+ntfs_version,0.9.2
 tartare_contributor_id,DefaultContributorId
 tartare_platform,dev

--- a/tests/fixtures/kv12ntfs/output/feed_infos.txt
+++ b/tests/fixtures/kv12ntfs/output/feed_infos.txt
@@ -6,6 +6,6 @@ feed_license,license
 feed_license_url,http://www.datasource-website.com
 feed_publisher_name,SYNTUS
 feed_start_date,20190424
-ntfs_version,0.9.3
+ntfs_version,0.9.2
 tartare_contributor_id,SYNTUS
 tartare_platform,dev

--- a/tests/fixtures/merge-ntfs/output_feedinfos/feed_infos.txt
+++ b/tests/fixtures/merge-ntfs/output_feedinfos/feed_infos.txt
@@ -6,6 +6,6 @@ feed_license,CoverageLicense
 feed_license_url,http://www.coverage-license.org
 feed_publisher_name,CoverageName
 feed_start_date,20170607
-ntfs_version,0.9.3
+ntfs_version,0.9.2
 tartare_coverage_id,cn
 tartare_platform,prod

--- a/tests/fixtures/merge-stop-areas/output/feed_infos.txt
+++ b/tests/fixtures/merge-stop-areas/output/feed_infos.txt
@@ -8,4 +8,4 @@ feed_publisher_url,
 feed_start_date,20170607
 fusio_url,http://vip-fusio-ihm.FR-IDF-OPEN.prod.canaltp.fr/
 fusio_version,1.10.89.209
-ntfs_version,0.9.3
+ntfs_version,0.9.2

--- a/tests/fixtures/netexidf2ntfs/output/feed_infos.txt
+++ b/tests/fixtures/netexidf2ntfs/output/feed_infos.txt
@@ -6,6 +6,6 @@ feed_license,license
 feed_license_url,http://www.datasource-website.com
 feed_publisher_name,IDF
 feed_start_date,+2621431231
-ntfs_version,0.9.3
+ntfs_version,0.9.2
 tartare_contributor_id,IDF
 tartare_platform,dev

--- a/tests/fixtures/restrict-validity-period/output/feed_infos.txt
+++ b/tests/fixtures/restrict-validity-period/output/feed_infos.txt
@@ -3,4 +3,4 @@ feed_creation_date,20190403
 feed_creation_time,17:19:00
 feed_end_date,20180805
 feed_start_date,20180501
-ntfs_version,0.9.3
+ntfs_version,0.9.2

--- a/tests/fixtures/transxchange2ntfs/output/ntfs/feed_infos.txt
+++ b/tests/fixtures/transxchange2ntfs/output/ntfs/feed_infos.txt
@@ -6,6 +6,6 @@ feed_license,license
 feed_license_url,http://www.datasource-website.com
 feed_publisher_name,UK
 feed_start_date,20180513
-ntfs_version,0.9.3
+ntfs_version,0.9.2
 tartare_contributor_id,UK
 tartare_platform,dev


### PR DESCRIPTION
We are currently on version 0.9.2.
Next version will be 0.10.0 with the field "trip_short_name_at_stop" (see https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_changelog_fr.md)
There will never be version 0.9.3.