### PR TITLE
Improve workspace and version definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ matrix:
   allow_failures:
   - rust: nightly
 script:
-- cargo test --verbose --features proj
-- cd model-builder && cargo test --verbose
-- cd ../collection && cargo test --verbose
-- cd ../relations && cargo test --verbose
+- cargo test --all --verbose --features proj
 deploy:
   provider: cargo
   on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "CanalTP/transit_model" }
 
+[workspace]
+members = [
+  "collection",
+  "relations",
+  "model-builder",
+  "transit_model_procmacro",
+]
+
 [features]
 stop_location = []
 


### PR DESCRIPTION
Define the workspace. Will be useful for CanalTP/transit_model#406 and the `--all` option.