### PR TITLE
Add SPDX license identifier

### DIFF
--- a/benches/apply_rules.rs
+++ b/benches/apply_rules.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/benches/filter_ntfs.rs
+++ b/benches/filter_ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/benches/read_gtfs.rs
+++ b/benches/read_gtfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/benches/read_kv1.rs
+++ b/benches/read_kv1.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/benches/read_ntfs.rs
+++ b/benches/read_ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/benches/read_transxchange.rs
+++ b/benches/read_transxchange.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/collection/src/collection.rs
+++ b/collection/src/collection.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/collection/src/lib.rs
+++ b/collection/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/examples/gtfs_reader.rs
+++ b/examples/gtfs_reader.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/model-builder/src/builder.rs
+++ b/model-builder/src/builder.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/model-builder/src/lib.rs
+++ b/model-builder/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/relations/src/lib.rs
+++ b/relations/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/relations/src/relations.rs
+++ b/relations/src/relations.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/add_prefix.rs
+++ b/src/add_prefix.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/apply_rules.rs
+++ b/src/apply_rules.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/common_format.rs
+++ b/src/common_format.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/hellogo_fares/mod.rs
+++ b/src/hellogo_fares/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/hellogo_fares/read.rs
+++ b/src/hellogo_fares/read.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/hellogo_fares/utils.rs
+++ b/src/hellogo_fares/utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/kv1/read.rs
+++ b/src/kv1/read.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/merge_stop_areas.rs
+++ b/src/merge_stop_areas.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/minidom_utils/mod.rs
+++ b/src/minidom_utils/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/minidom_utils/try_attribute.rs
+++ b/src/minidom_utils/try_attribute.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/minidom_utils/try_only_child.rs
+++ b/src/minidom_utils/try_only_child.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_idf/lines.rs
+++ b/src/netex_idf/lines.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_idf/mod.rs
+++ b/src/netex_idf/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_idf/modes.rs
+++ b/src/netex_idf/modes.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_idf/offers.rs
+++ b/src/netex_idf/offers.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_idf/read.rs
+++ b/src/netex_idf/read.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_idf/stops.rs
+++ b/src/netex_idf/stops.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/netex_utils/mod.rs
+++ b/src/netex_utils/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/ntfs/filter.rs
+++ b/src/ntfs/filter.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/ntfs/write.rs
+++ b/src/ntfs/write.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/transfers.rs
+++ b/src/transfers.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/transxchange/bank_holidays.rs
+++ b/src/transxchange/bank_holidays.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/transxchange/mod.rs
+++ b/src/transxchange/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/transxchange/naptan.rs
+++ b/src/transxchange/naptan.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/transxchange/operating_profile.rs
+++ b/src/transxchange/operating_profile.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/transxchange/read.rs
+++ b/src/transxchange/read.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/src/vptranslator.rs
+++ b/src/vptranslator.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/apply_rules.rs
+++ b/tests/apply_rules.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/enrich_with_hellogo_fares.rs
+++ b/tests/enrich_with_hellogo_fares.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/filter_ntfs.rs
+++ b/tests/filter_ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/gtfs2ntfs.rs
+++ b/tests/gtfs2ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/merge_ntfs.rs
+++ b/tests/merge_ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/merge_stop_areas.rs
+++ b/tests/merge_stop_areas.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/netexidf2ntfs.rs
+++ b/tests/netexidf2ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/ntfs2gtfs.rs
+++ b/tests/ntfs2gtfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/read_kv1.rs
+++ b/tests/read_kv1.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/read_transxchange.rs
+++ b/tests/read_transxchange.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/restrict_validity_period.rs
+++ b/tests/restrict_validity_period.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/tests/transfers.rs
+++ b/tests/transfers.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or

--- a/transit_model_procmacro/src/lib.rs
+++ b/transit_model_procmacro/src/lib.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
 // Copyright 2017 Kisio Digital and/or its affiliates.
 //
 // This program is free software: you can redistribute it and/or


### PR DESCRIPTION
In relation with https://spdx.org/, this is a proposition.