### PR TITLE
Specs gtfs2ntfs: reading calendars & common pre-processing

### DIFF
--- a/src/documentation/common.md
+++ b/src/documentation/common.md
@@ -1,21 +1,22 @@
 # Shared specifications for all converters
 This document explains the shared parts among all the converters when converting a 
-data set from a given format into a [NTFS](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis) dataset.
+data set from a given format into a [NTFS](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md) dataset.
 
 ## Data prefix
 The construction of NTFS objects IDs requires, for uniqueness purpose, that a unique 
-prefix (specified for each source of data as an addtional parameter to each converter)
+prefix (specified for each source of data as an additional parameter to each converter)
 needs to be included in every object's id.
 
 Prepending all the identifiers with a unique prefix ensures that the NTFS identifiers are unique accross all the NTFS datasets. With this assumption, merging two NTFS datasets can be done without worrying about conflicting identifiers.
 
-This prefix should be applied to all NTFS identifier except for the physical_mode identifiers that are standarized and fixed values. Fixed values are described in the [NTFS specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis)
+This prefix should be applied to all NTFS identifier except for the physical mode identifiers that are standarized and fixed values. Fixed values are described in the [NTFS specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis)
 
 ## Configuration of each converter
 A configuration file `config.json`, as it is shown below, is provided for each 
 converter and contains additional information about the data source as well as about 
-the upstream system that generated the data (if available). In particular, it 
-provides the necessary information for the required NTFS files datasets.txt and contributors.txt.
+the upstream system that generated the data (if available). In particular, it provides the necessary information for:
+- the required NTFS files `contributors.txt` and `datasets.txt`
+- some additional metadata can also be inserted in the file `feed_infos.txt`.
 
 ```json
 {
@@ -38,16 +39,8 @@ provides the necessary information for the required NTFS files datasets.txt and 
 The objects `contributor` and `dataset` are required, containing at least the 
 corresponding identifier (and the name for `contributor`), otherwise the conversion 
 stops with an error. The object `feed_infos` is optional.
-The files datasets.txt and contributors.txt provide additional information about the data source.
 
-### Loading Dataset
-
-| NTFS file | NTFS field | key in `config.json` | Constraint | Note |
-| --- | --- | --- | --- | ---
-| datasets.txt | dataset_id | dataset_id | Required | This field is prefixed.
-| datasets.txt | contributor_id | contributor_id | Required | This field is prefixed.
-| datasets.txt | dataset_start_date |  |  | Date of the first trip of the dataset (including all lines of all networks).
-| datasets.txt | dataset_end_date |  |  | Date of the last trip of the dataset (including all lines of all networks).
+The files `contributors.txt` and `datasets.txt` provide additional information about the data source.
 
 ### Loading Contributor
 
@@ -57,3 +50,12 @@ The files datasets.txt and contributors.txt provide additional information about
 | contributors.txt | contributor_name | contributor_name | Required | 
 | contributors.txt | contributor_license | contributor_license | Optional | 
 | contributors.txt | contributor_website | contributor_website | Optional | 
+
+### Loading Dataset
+
+| NTFS file | NTFS field | key in `config.json` | Constraint | Note |
+| --- | --- | --- | --- | ---
+| datasets.txt | dataset_id | dataset_id | Required | This field is prefixed.
+| datasets.txt | contributor_id | contributor_id | Required | This field is prefixed.
+| datasets.txt | dataset_start_date |  |  | Smallest date of all the trips of the dataset.
+| datasets.txt | dataset_end_date |  |  | Greatest date of all the trips of the dataset.

--- a/src/documentation/common.md
+++ b/src/documentation/common.md
@@ -1,0 +1,59 @@
+# Shared specifications for all converters
+This document explains the shared parts among all the converters when converting a 
+data set from a given format into a [NTFS](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis) dataset.
+
+## Data prefix
+The construction of NTFS objects IDs requires, for uniqueness purpose, that a unique 
+prefix (specified for each source of data as an addtional parameter to each converter)
+needs to be included in every object's id.
+
+Prepending all the identifiers with a unique prefix ensures that the NTFS identifiers are unique accross all the NTFS datasets. With this assumption, merging two NTFS datasets can be done without worrying about conflicting identifiers.
+
+This prefix should be applied to all NTFS identifier except for the physical_mode identifiers that are standarized and fixed values. Fixed values are described in the [NTFS specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis)
+
+## Configuration of each converter
+A configuration file `config.json`, as it is shown below, is provided for each 
+converter and contains additional information about the data source as well as about 
+the upstream system that generated the data (if available). In particular, it 
+provides the necessary information for the required NTFS files datasets.txt and contributors.txt.
+
+```json
+{
+    "contributor": {
+        "contributor_id": "DefaultContributorId",
+        "contributor_name": "DefaultContributorName",
+        "contributor_license": "DefaultDatasourceLicense",
+        "contributor_website": "http://www.default-datasource-website.com"
+    },
+    "dataset": {
+        "dataset_id": "DefaultDatasetId"
+    },
+    "feed_infos": {
+        "feed_publisher_name": "DefaultContributorName",
+        "feed_license": "DefaultDatasourceLicense",
+        "feed_license_url": "http://www.default-datasource-website.com",
+    }
+}
+```
+The objects `contributor` and `dataset` are required, containing at least the 
+corresponding identifier (and the name for `contributor`), otherwise the conversion 
+stops with an error. The object `feed_infos` is optional.
+The files datasets.txt and contributors.txt provide additional information about the data source.
+
+### Loading Dataset
+
+| NTFS file | NTFS field | key in `config.json` | Constraint | Note |
+| --- | --- | --- | --- | ---
+| datasets.txt | dataset_id | dataset_id | Required | This field is prefixed.
+| datasets.txt | contributor_id | contributor_id | Required | This field is prefixed.
+| datasets.txt | dataset_start_date |  |  | Date of the first trip of the dataset (including all lines of all networks).
+| datasets.txt | dataset_end_date |  |  | Date of the last trip of the dataset (including all lines of all networks).
+
+### Loading Contributor
+
+| NTFS file | NTFS field | key in `config.json` | Constraint | Note |
+| --- | --- | --- | --- | ---
+| contributors.txt | contributor_id | contributor_id | Required | This field is prefixed.
+| contributors.txt | contributor_name | contributor_name | Required | 
+| contributors.txt | contributor_license | contributor_license | Optional | 
+| contributors.txt | contributor_website | contributor_website | Optional | 

--- a/src/documentation/common.md
+++ b/src/documentation/common.md
@@ -9,7 +9,7 @@ needs to be included in every object's id.
 
 Prepending all the identifiers with a unique prefix ensures that the NTFS identifiers are unique accross all the NTFS datasets. With this assumption, merging two NTFS datasets can be done without worrying about conflicting identifiers.
 
-This prefix should be applied to all NTFS identifier except for the physical mode identifiers that are standarized and fixed values. Fixed values are described in the [NTFS specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis)
+This prefix should be applied to all NTFS identifiers except for the physical mode identifiers that are standardized and fixed values. Fixed values are described in the [NTFS specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis)
 
 ## Configuration of each converter
 A configuration file `config.json`, as it is shown below, is provided for each 

--- a/src/documentation/data_prefix.md
+++ b/src/documentation/data_prefix.md
@@ -1,6 +1,0 @@
-# Data prefix
-
-When converting a data set from a format to a NTFS dataset, a prefix can be added to all the identifiers.
-Prepending all the identifiers with a unique prefix ensures that the NTFS identifiers are unique accross all the NTFS datasets. With this assumption, merging two NTFS datasets can be done without worrying about conflicting identifiers.
-
-This prefix should be applied to all NTFS identifier except for the physical_mode identifiers that are standarized and fixed values. Fixed values are described in the [NTFS specifications](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#physical_modestxt-requis)

--- a/src/documentation/gtfs_to_ntfs_specs.md
+++ b/src/documentation/gtfs_to_ntfs_specs.md
@@ -180,7 +180,7 @@ specified, the conversion should stop immediately with an error.
 (1) When several GTFS Routes with different `route_type`s are grouped together, the commercial_mode_id with the smallest priority should be used (as specified in chapter "Mapping of route_type with modes").
 
 ### Reading calendars.txt and calendar_dates.txt
-GTFS services are trasnformed into lists of active dates as if using a single NTFS 
+GTFS services are transformed into lists of active dates as if using a single NTFS 
 file `calendar_dates.txt`. The resulting NTFS files might be different following an 
 optimization operation applied at the end of the conversion, but the result should be 
 functionally identical.

--- a/src/documentation/gtfs_to_ntfs_specs.md
+++ b/src/documentation/gtfs_to_ntfs_specs.md
@@ -16,7 +16,7 @@ As explained in [common.md](common.md), a prefix is added to all identifiers dur
 In the following chapters, identifiers may be prepend with this _prefix_ using this pattern : **\<prefix>:<object\_id>**.
 The use of this specific pattern is shown explicitly using the value **ID** in the column _Constraint_ in the tables below.
 
-In addition, the NTFS format introduces 2 objects to enable the manipulation of several datasets : contributors and datasets. Those two objects are not described here, see [common.md](common.md) for more information. 
+In addition, the NTFS format introduces 2 objects to enable the manipulation of several datasets: contributors and datasets. Those two objects are described in [common.md](common.md). 
 
 ## Mapping of objects between GTFS and NTFS
 | GTFS object | NTFS object(s) |
@@ -180,15 +180,12 @@ specified, the conversion should stop immediately with an error.
 (1) When several GTFS Routes with different `route_type`s are grouped together, the commercial_mode_id with the smallest priority should be used (as specified in chapter "Mapping of route_type with modes").
 
 ### Reading calendars.txt and calendar_dates.txt
-Dates of service are trasnformed into explicit active service exceptions as if using a single NTFS file calendar_dates.txt. The resulting files might be different following an optimization operation applied at the end of the conversion, but the result should be functionally identical.
-* In case both files calendar.txt and calendar_dates.txt are present in the input dataset, the days of the week of the specified services within the date range [`start_date` - `end_date`] are transformed into explicit active service dates, taking into account the dates when service exceptions occur. Note that the generated (`service_id`, `date`) pairs must be unique.
-* In case the file calendar.txt is empty or not present in the input dataset, the active service dates are loaded as is.
-
-| NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
-| --- | --- | --- | --- | --- | --- |
-| calendar_dates.txt | service_id | Required | calendar_dates.txt | service_id | All slashes `/` are removed
-| calendar_dates.txt | date | Required | calendar_dates.txt | date |
-| calendar_dates.txt | exception_type | Required | calendar_dates.txt | exception_type | Fixed value `1`.
+GTFS services are trasnformed into lists of active dates as if using a single NTFS 
+file `calendar_dates.txt`. The resulting NTFS files might be different following an 
+optimization operation applied at the end of the conversion, but the result should be 
+functionally identical.
+* In case both files `calendar.txt` and `calendar_dates.txt` are present in the input dataset, the days of the week of the specified services within the date range [`start_date` - `end_date`] are transformed into explicit active service dates, taking into account the dates when service exceptions occur. Note that the generated (`service_id`, `date`) pairs must be unique.
+* In case the file `calendar.txt` is empty or not present in the input dataset, the active service dates are loaded as is.
 
 ### Reading trips.txt
 If 2 trips with the same ID are specified, the conversion should stop

--- a/src/documentation/gtfs_to_ntfs_specs.md
+++ b/src/documentation/gtfs_to_ntfs_specs.md
@@ -12,10 +12,11 @@ At the end of the conversion, a sanitizing operation is started on the final
 model. See [sanitizer.md](sanitizer.md) for more information.
 
 ### Prepending data
-The NTFS format introduce 2 objects to enable the manipulation of several datasets : contributors and datasets. Those two objects are not described here. The construction of NTFS objects IDs requires, for uniqueness purpose, that a unique prefix (specified for each source of data) needs to be included in every object's id.
-
+As explained in [common.md](common.md), a prefix is added to all identifiers during the conversion in order to guarantee uniqueness among objects IDs.
 In the following chapters, identifiers may be prepend with this _prefix_ using this pattern : **\<prefix>:<object\_id>**.
 The use of this specific pattern is shown explicitly using the value **ID** in the column _Constraint_ in the tables below.
+
+In addition, the NTFS format introduces 2 objects to enable the manipulation of several datasets : contributors and datasets. Those two objects are not described here, see [common.md](common.md) for more information. 
 
 ## Mapping of objects between GTFS and NTFS
 | GTFS object | NTFS object(s) |
@@ -177,6 +178,17 @@ specified, the conversion should stop immediately with an error.
 | lines.txt | commercial_mode_id | Required | routes.txt | route_type | See "Mapping of route_type with modes" chapter (1). |
 
 (1) When several GTFS Routes with different `route_type`s are grouped together, the commercial_mode_id with the smallest priority should be used (as specified in chapter "Mapping of route_type with modes").
+
+### Reading calendars.txt and calendar_dates.txt
+Dates of service are trasnformed into explicit active service exceptions as if using a single NTFS file calendar_dates.txt. The resulting files might be different following an optimization operation applied at the end of the conversion, but the result should be functionally identical.
+* In case both files calendar.txt and calendar_dates.txt are present in the input dataset, the days of the week of the specified services within the date range [`start_date` - `end_date`] are transformed into explicit active service dates, taking into account the dates when service exceptions occur. Note that the generated (`service_id`, `date`) pairs must be unique.
+* In case the file calendar.txt is empty or not present in the input dataset, the active service dates are loaded as is.
+
+| NTFS file | NTFS field | Constraint | GTFS file | GTFS field | Note |
+| --- | --- | --- | --- | --- | --- |
+| calendar_dates.txt | service_id | Required | calendar_dates.txt | service_id | All slashes `/` are removed
+| calendar_dates.txt | date | Required | calendar_dates.txt | date |
+| calendar_dates.txt | exception_type | Required | calendar_dates.txt | exception_type | Fixed value `1`.
 
 ### Reading trips.txt
 If 2 trips with the same ID are specified, the conversion should stop


### PR DESCRIPTION
I added the specs on reading calendars and I modified the file data_prefix.md to common.md where I put together the common parts for all converters: for now, the specs on data prefix and datasets/contributors.
Eventually, santizer will be part of this file too.