### PR TITLE
Remove --all [deprecated] in favor of --workspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
   - rust: stable
     name: Quality check
     before_script: rustup component add clippy
-    script: cargo clippy --all --all-features -- -D warnings
+    script: cargo clippy --workspace --all-features -- -D warnings
   allow_failures:
   - rust: nightly
 script:
-- cargo test --all --verbose --features proj
+- cargo test --workspace --verbose --features proj
 deploy:
   provider: cargo
   on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For the static analysis, we use [`clippy`].
 
 ```sh
 # To format the source code in the entire repository
-cargo clippy --all
+cargo clippy --workspace
 ```
 
 [`clippy`]: https://github.com/rust-lang/rust-clippy
@@ -49,7 +49,7 @@ The test suite include unit test and integration tests.
 
 ```sh
 # Run all the tests of `transit_model` in the entire repository
-cargo test --all --all-features
+cargo test --workspace --all-features
 ```
 
 ## Conduct


### PR DESCRIPTION
This is an update related to the new version Rust 1.39 released on 07/10/2019. See https://github.com/rust-lang/cargo/pull/7241/. Interesting note: it seems this doesn't work for `cargo fmt` which still takes `--all` argument and doesn't accept `--workspace`.