### PR TITLE
Exclude all useless files from the Cargo publishing process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,21 @@ description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"
 keywords = ["ntfs", "gtfs", "netex", "navitia", "transit"]
 edition = "2018"
+exclude = [
+	".gitignore",
+	".mergify.yml",
+	".travis.yml",
+	"CONTRIBUTING.md",
+	"README.md",
+	"benches/",
+	"collection/",
+	"examples/",
+	"model-builder/",
+	"relations/",
+	"src/documentation/",
+	"tests/",
+	"transit_model_procmacro/",
+]
 
 [badges]
 travis-ci = { repository = "CanalTP/transit_model" }


### PR DESCRIPTION
So far, all of our released crates contained a lot of useless files, particularly all the fixtures files. This `package.exclude` should remove all useless files during the publishing process.