### PR TITLE
Bump all versions to the next version to be released

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.11.0"
+version = "0.11.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/collection/Cargo.toml
+++ b/collection/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transit_model_collection"
 description = "Manage collection of objects"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/model-builder/Cargo.toml
+++ b/model-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transit_model_builder"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Antoine Desbordes <antoine.desbordes@gmail.com>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/relations/Cargo.toml
+++ b/relations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transit_model_relations"
 description = " Modeling the relations between objects"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/transit_model_procmacro/Cargo.toml
+++ b/transit_model_procmacro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transit_model_procmacro"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 license = "AGPL-3.0-only"
 description = "A private procmacro crate for the transit_model crate"


### PR DESCRIPTION
This has been already discussed but the idea would be to always have the next version to be released in the files `Cargo.toml`. By default, we're considering the next minor version (more precisely, considering the next version doesn't have a breaking change). For versions strictly lower than `1.0.0`, we would bump from `0.12.2` to `0.12.3`; and for versions greater than `1.0.0`, we would bump from `1.4.7` to `1.5.0`.

We would also need to agree on what a Breaking Change means. So far, this is the definition we've come up with but bare in mind it's not final and still up for the discussion.

# Breaking change
First of all, this concerns public APIs (including functions signatures and objects for a library, arguments and name of parameters for a binary). All private APIs are usually not concerned.

Secondly, adding a new function or a new structure or a new parameter to a binary is not a breaking change. However, modifying the name of a function, a parameter (in a function signature or in a binary's parameter), an object (modifying also include removal) would be a breaking change. That would also include making private a API that were public before.

One more fuzzy part is about the result of the processing. Let's say we do not change any signature, or any object in our library. But an internal implementation changed which resulted in a change in the business result (we're producing NTFS, so maybe some objects that were present before are not anymore). Should this be considered a breaking change?