### PR TITLE
Extract validity_period's related function into it's own module

### DIFF
--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     objects::{StopPoint, StopType, Time},
     read_utils,
     utils::*,
-    AddPrefix, Result,
+    validity_period, AddPrefix, Result,
 };
 use derivative::Derivative;
 use log::info;
@@ -271,7 +271,7 @@ where
     manage_calendars(file_handler, &mut collections)?;
 
     let (contributor, mut dataset, feed_infos) = read_utils::read_config(config_path)?;
-    read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
+    validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
     collections.contributors = CollectionWithId::new(vec![contributor])?;
     collections.datasets = CollectionWithId::new(vec![dataset])?;

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -16,15 +16,17 @@ use super::{
     Agency, DirectionType, Route, RouteType, Shape, Stop, StopLocationType, StopTime, Transfer,
     TransferType, Trip,
 };
-use crate::common_format::Availability;
-use crate::model::Collections;
-use crate::objects::{
-    self, CommentLinksT, Coord, KeysValues, Pathway, StopLocation, StopTime as NtfsStopTime,
-    StopType, Time, TransportType, VehicleJourney,
+use crate::{
+    common_format::Availability,
+    model::Collections,
+    objects::{
+        self, CommentLinksT, Coord, KeysValues, Pathway, StopLocation, StopTime as NtfsStopTime,
+        StopType, Time, TransportType, VehicleJourney,
+    },
+    read_utils::{read_collection, read_objects, FileHandler},
+    utils::*,
+    Result,
 };
-use crate::read_utils::{read_collection, read_objects, FileHandler};
-use crate::utils::*;
-use crate::Result;
 use csv;
 use derivative::Derivative;
 use failure::{bail, format_err, Error, ResultExt};
@@ -1196,7 +1198,7 @@ mod tests {
         },
         read_utils::{self, read_opt_collection, PathFileHandler},
         test_utils::*,
-        AddPrefix,
+        validity_period, AddPrefix,
     };
     use geo_types::line_string;
     use pretty_assertions::assert_eq;
@@ -2658,7 +2660,8 @@ mod tests {
             let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
             common_format::manage_calendars(&mut handler, &mut collections).unwrap();
-            read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars).unwrap();
+            validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)
+                .unwrap();
 
             assert_eq!(
                 Dataset {
@@ -2689,7 +2692,8 @@ mod tests {
             let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
             common_format::manage_calendars(&mut handler, &mut collections).unwrap();
-            read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars).unwrap();
+            validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)
+                .unwrap();
 
             assert_eq!(
                 Dataset {

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -18,7 +18,7 @@ mod read;
 
 use crate::{
     model::{Collections, Model},
-    read_utils, AddPrefix, Result,
+    read_utils, validity_period, AddPrefix, Result,
 };
 use std::path::Path;
 use transit_model_collection::CollectionWithId;
@@ -36,7 +36,7 @@ where
     read::read_operday(file_handler, &mut collections)?;
 
     let (contributor, mut dataset, feed_infos) = read_utils::read_config(config_path)?;
-    read_utils::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
+    validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
     collections.contributors = CollectionWithId::new(vec![contributor])?;
     collections.datasets = CollectionWithId::new(vec![dataset])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod test_utils;
 pub mod transfers;
 #[cfg(feature = "proj")]
 pub mod transxchange;
+mod validity_period;
 pub mod vptranslator;
 
 /// Current version of the NTFS format

--- a/src/netex_idf/offers.rs
+++ b/src/netex_idf/offers.rs
@@ -25,7 +25,7 @@ use crate::{
     objects::{
         Calendar, Dataset, Date, Route, StopPoint, StopTime, Time, ValidityPeriod, VehicleJourney,
     },
-    read_utils, Result,
+    validity_period, Result,
 };
 use failure::{bail, format_err, ResultExt};
 use log::{info, warn};
@@ -357,7 +357,7 @@ fn update_validity_period_from_netex_idf(
 ) -> Result<CollectionWithId<Dataset>> {
     let mut datasets = datasets.take();
     for dataset in &mut datasets {
-        read_utils::update_validity_period(dataset, &validity_period);
+        validity_period::update_validity_period(dataset, &validity_period);
     }
     CollectionWithId::new(datasets)
 }

--- a/src/transxchange/read.rs
+++ b/src/transxchange/read.rs
@@ -16,9 +16,8 @@ use crate::{
     minidom_utils::TryOnlyChild,
     model::{Collections, Model},
     objects::*,
-    read_utils,
     transxchange::{bank_holidays, bank_holidays::BankHoliday, naptan},
-    AddPrefix, Result,
+    validity_period, AddPrefix, Result,
 };
 use chrono::{
     naive::{NaiveDate, MAX_DATE, MIN_DATE},
@@ -127,7 +126,7 @@ fn update_validity_period_from_transxchange(
     let service_validity_period = get_service_validity_period(transxchange, max_end_date)?;
     let mut datasets = datasets.take();
     for dataset in &mut datasets {
-        read_utils::update_validity_period(dataset, &service_validity_period);
+        validity_period::update_validity_period(dataset, &service_validity_period);
     }
     CollectionWithId::new(datasets)
 }

--- a/src/validity_period.rs
+++ b/src/validity_period.rs
@@ -1,0 +1,137 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+
+//! Some utilities to set and/or calculate validity periods.
+use crate::{
+    objects::{Calendar, Dataset, ValidityPeriod},
+    Result,
+};
+use std::collections::BTreeSet;
+use transit_model_collection::CollectionWithId;
+
+pub fn get_validity_period(calendars: &CollectionWithId<Calendar>) -> Option<ValidityPeriod> {
+    let dates = calendars.values().fold(BTreeSet::new(), |acc, c| {
+        acc.union(&c.dates).cloned().collect()
+    });
+
+    if dates.is_empty() {
+        return None;
+    }
+
+    Some(ValidityPeriod {
+        start_date: *dates.iter().next().unwrap(),
+        end_date: *dates.iter().next_back().unwrap(),
+    })
+}
+
+pub fn set_dataset_validity_period(
+    dataset: &mut Dataset,
+    calendars: &CollectionWithId<Calendar>,
+) -> Result<()> {
+    let validity_period = get_validity_period(calendars);
+
+    if let Some(vp) = validity_period {
+        dataset.start_date = vp.start_date;
+        dataset.end_date = vp.end_date;
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "proj")]
+pub fn update_validity_period(dataset: &mut Dataset, service_validity_period: &ValidityPeriod) {
+    dataset.start_date = if service_validity_period.start_date < dataset.start_date {
+        service_validity_period.start_date
+    } else {
+        dataset.start_date
+    };
+    dataset.end_date = if service_validity_period.end_date > dataset.end_date {
+        service_validity_period.end_date
+    } else {
+        dataset.end_date
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "proj")]
+    mod update_validity_period {
+        use super::*;
+        use crate::objects::{Dataset, Date, ValidityPeriod};
+        use chrono::naive::{MAX_DATE, MIN_DATE};
+        use pretty_assertions::assert_eq;
+
+        #[test]
+        fn no_existing_validity_period() {
+            let start_date = Date::from_ymd(2019, 1, 1);
+            let end_date = Date::from_ymd(2019, 6, 30);
+            let mut dataset = Dataset {
+                id: String::from("dataset_id"),
+                contributor_id: String::from("contributor_id"),
+                start_date: MAX_DATE,
+                end_date: MIN_DATE,
+                ..Default::default()
+            };
+            let service_validity_period = ValidityPeriod {
+                start_date,
+                end_date,
+            };
+            update_validity_period(&mut dataset, &service_validity_period);
+            assert_eq!(start_date, dataset.start_date);
+            assert_eq!(end_date, dataset.end_date);
+        }
+
+        #[test]
+        fn with_extended_validity_period() {
+            let start_date = Date::from_ymd(2019, 1, 1);
+            let end_date = Date::from_ymd(2019, 6, 30);
+            let mut dataset = Dataset {
+                id: String::from("dataset_id"),
+                contributor_id: String::from("contributor_id"),
+                start_date: Date::from_ymd(2019, 3, 1),
+                end_date: Date::from_ymd(2019, 4, 30),
+                ..Default::default()
+            };
+            let service_validity_period = ValidityPeriod {
+                start_date,
+                end_date,
+            };
+            update_validity_period(&mut dataset, &service_validity_period);
+            assert_eq!(start_date, dataset.start_date);
+            assert_eq!(end_date, dataset.end_date);
+        }
+
+        #[test]
+        fn with_included_validity_period() {
+            let start_date = Date::from_ymd(2019, 1, 1);
+            let end_date = Date::from_ymd(2019, 6, 30);
+            let mut dataset = Dataset {
+                id: String::from("dataset_id"),
+                contributor_id: String::from("contributor_id"),
+                start_date,
+                end_date,
+                ..Default::default()
+            };
+            let service_validity_period = ValidityPeriod {
+                start_date: Date::from_ymd(2019, 3, 1),
+                end_date: Date::from_ymd(2019, 4, 30),
+            };
+            update_validity_period(&mut dataset, &service_validity_period);
+            assert_eq!(start_date, dataset.start_date);
+            assert_eq!(end_date, dataset.end_date);
+        }
+    }
+}


### PR DESCRIPTION
Dear reviewers,
I'm curious about your opinion on moving `crate::objects::ValidityPeriod` into the new modules `crate::validity_period`?