### PR TITLE
[tech] Bump version to catch up on our new strategy (see #458)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.11.0"
+version = "0.11.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"


### PR DESCRIPTION
We closed #458 since we want to let each contributor bump the version as they need to. But we need to catch up from the last version `0.11.0` (we've already produced code since and the version has not been bumped since).

Usually, I would have bumped to `0.11.1` but I believe the PR #455 is breaking change (we're changing from NTFS `v0.9.2` to NTFS `v0.10.0`.