### PR TITLE
[fix] Netex - Skip line without network

### DIFF
--- a/src/netex_idf/lines.rs
+++ b/src/netex_idf/lines.rs
@@ -342,6 +342,47 @@ mod tests {
     }
 
     #[test]
+    fn test_load_netex_lines_with_one_without_network() {
+        let xml = r#"
+            <ServiceFrame>
+               <lines>
+                  <Line id="FR1:Line:C00001">
+                     <Name>Line 01</Name>
+                     <ShortName>01</ShortName>
+                     <TransportMode>bus</TransportMode>
+                     <RepresentedByGroupRef ref="FR1:Network:1:LOC"/>
+                     <OperatorRef ref="FR1:Operator:1:LOC"/>
+                  </Line>
+                  <Line id="FR1:Line:C00002">
+                     <Name>Line 02</Name>
+                     <ShortName>02</ShortName>
+                     <TransportMode>bus</TransportMode>                     
+                     <OperatorRef ref="FR1:Operator:1:LOC"/>
+                  </Line>
+               </lines>
+            </ServiceFrame>"#;
+        let mut frames = HashMap::new();
+        let service_frame_lines: Element = xml.parse().unwrap();
+        frames.insert(FrameType::Service, vec![&service_frame_lines]);
+
+        let networks = CollectionWithId::new(vec![Network {
+            id: String::from("FR1:Network:1:LOC"),
+            name: String::from("Network1"),
+            ..Default::default()
+        }])
+        .unwrap();
+        let companies = CollectionWithId::new(vec![Company {
+            id: String::from("FR1:Operator:1:LOC"),
+            name: String::from("Operator1"),
+            ..Default::default()
+        }])
+        .unwrap();
+
+        let (lines_netex_idf, _) = load_netex_lines(&frames, &networks, &companies).unwrap();
+        assert_eq!(1, lines_netex_idf.len());
+    }
+
+    #[test]
     fn test_color_parent_node() {
         let xml = r#"
               <Line id="FR1:Line:C00001"></Line>"#;

--- a/src/netex_idf/lines.rs
+++ b/src/netex_idf/lines.rs
@@ -116,9 +116,9 @@ fn load_netex_lines(
                     .map(Element::text)
                     .ok();
                 let private_code = line.only_child("PrivateCode").map(Element::text);
-                let network_id: String = line
-                    .try_only_child("RepresentedByGroupRef")?
-                    .try_attribute("ref")?;
+                let network_id: String = skip_fail!(line
+                    .try_only_child("RepresentedByGroupRef")
+                    .and_then(|netref| netref.try_attribute("ref")));
                 if !networks.contains_id(&network_id) {
                     warn!("Failed to find network {} for line {}", network_id, id);
                     continue;


### PR DESCRIPTION
Structure Line/RepresentedByGroupRef/@ref can not exist. It is not an obligatory field, and according to specifications the line should be skipped.