### PR TITLE
Deprecate model-builder crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ travis-ci = { repository = "CanalTP/transit_model" }
 members = [
   "collection",
   "relations",
-  "model-builder",
   "transit_model_procmacro",
 ]
 

--- a/model-builder/README.md
+++ b/model-builder/README.md
@@ -1,0 +1,9 @@
+⚠ This crates is not maintained anymore and might be out of date for
+`transit_model`.
+
+Model Builder for `transit_model`
+=====
+
+This crates helps to build a new `transit_model::Model` with a [Builder
+Pattern](https://www.wikiwand.com/en/Builder_pattern). It provides only a
+partial implementation for routes, vehicle journeys, and calendars.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,6 @@ lazy_static::lazy_static! {
     pub static ref CURRENT_DATETIME: String = chrono::Local::now().format("%FT%T").to_string();
 }
 
-#[cfg(test)]
-#[path = "../model-builder/src/builder.rs"]
-pub mod model_builder;
-
 /// The error type used by the crate.
 pub type Error = failure::Error;
 


### PR DESCRIPTION
This Model Builder is only partial (it doesn't allow the creation of networks and lines for example). The problem is that we have ongoing work to sanitize automatically the `Model` on creation (in the `new()` method) which means that all the tests are breaking because a model that have `stop_times` which are not linked to a `line` are now sanitized...
Ping @antoine-de 