### PR TITLE
[tech] Skeleton for the Netex France exporter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub mod merge_stop_areas;
 mod minidom_utils;
 pub mod model;
 #[cfg(feature = "proj")]
+pub mod netex_france;
+#[cfg(feature = "proj")]
 pub mod netex_idf;
 mod netex_utils;
 pub mod ntfs;

--- a/src/netex_france/exporter.rs
+++ b/src/netex_france/exporter.rs
@@ -1,0 +1,116 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+
+//! Exporter for Netex France profile
+use crate::{model::Model, Result};
+use chrono::prelude::*;
+use minidom::Element;
+use std::{
+    convert::AsRef,
+    fmt::{self, Display, Formatter},
+    fs::File,
+    path::Path,
+};
+
+const NETEX_FRANCE_STOPS_FILENAME: &str = "arrets.xml";
+
+enum VersionType {
+    Stops,
+}
+
+impl Display for VersionType {
+    fn fmt(&self, fmt: &mut Formatter) -> std::result::Result<(), fmt::Error> {
+        use VersionType::*;
+        match self {
+            Stops => write!(fmt, "ARRET"),
+        }
+    }
+}
+
+/// Struct that can write an export of Netex France profile from a Model
+pub struct Exporter {
+    _model: Model,
+    participant_ref: String,
+    timestamp: NaiveDateTime,
+}
+
+// Publicly exposed methods
+impl Exporter {
+    /// Build a Netex France profile exporter from the model.
+    /// `path` is the expected output Path where the Netex France is going to be
+    /// written. It should be a folder that already exists.
+    pub fn new(_model: Model, participant_ref: String, timestamp: NaiveDateTime) -> Self {
+        Exporter {
+            _model,
+            participant_ref,
+            timestamp,
+        }
+    }
+
+    /// Actually write `model` into `path` as a Netex France profile.
+    pub fn write<P>(&self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        self.write_stops(path)?;
+        Ok(())
+    }
+}
+
+// Internal methods
+impl Exporter {
+    // Include 'stop_frame' into a complete NeTEx XML tree with
+    // 'PublicationDelivery' and 'dataObjects'
+    fn wrap_frame(&self, frame: Element, version_type: VersionType) -> Result<Element> {
+        let publication_timestamp = Element::builder("PublicationTimestamp")
+            .ns("http://www.netex.org.uk/netex/")
+            // FIXME: This is not compliant with ISO8601 (the final offset is missing)
+            .append(self.timestamp.format("%FT%T").to_string())
+            .build();
+        let participant_ref = Element::builder("ParticipantRef")
+            .ns("http://www.netex.org.uk/netex/")
+            .append(self.participant_ref.as_str())
+            .build();
+        let data_objects = Element::builder("dataObjects")
+            .ns("http://www.netex.org.uk/netex/")
+            .append(frame)
+            .build();
+        let root = Element::builder("PublicationDelivery")
+            .ns("http://www.netex.org.uk/netex/")
+            .attr("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
+            .attr("version", format!("1.09:FR-NETEX_{}-2.1-1.0", version_type))
+            .append(publication_timestamp)
+            .append(participant_ref)
+            .append(data_objects)
+            .build();
+        Ok(root)
+    }
+
+    fn write_stops<P>(&self, path: P) -> Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        let filepath = path.as_ref().join(NETEX_FRANCE_STOPS_FILENAME);
+        let _file = File::create(filepath)?;
+        let stop_frame = self.create_stops_frame()?;
+        let _netex = self.wrap_frame(stop_frame, VersionType::Stops)?;
+        Ok(())
+    }
+
+    // Returns a 'GeneralFrame' containing all 'StopArea' and 'Quay'
+    fn create_stops_frame(&self) -> Result<Element> {
+        let frame = Element::builder("GeneralFrame").build();
+        Ok(frame)
+    }
+}

--- a/src/netex_france/mod.rs
+++ b/src/netex_france/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+
+//! Module to handle Netex France profile
+
+mod exporter;
+
+pub use exporter::Exporter;

--- a/tests/write_netex_france.rs
+++ b/tests/write_netex_france.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+
+use transit_model::{self, netex_france, test_utils::*};
+
+#[test]
+fn test_write_netex_france() {
+    let model = transit_model::ntfs::read("tests/fixtures/ntfs").unwrap();
+    test_in_tmp_dir(|output_dir| {
+        let participant_ref = String::from("Participant");
+        let netex_france_exporter =
+            netex_france::Exporter::new(model, participant_ref, get_test_datetime());
+        netex_france_exporter.write(output_dir).unwrap();
+        compare_output_dir_with_expected(&output_dir, None, "tests/fixtures/netex_france");
+    });
+}


### PR DESCRIPTION
Just a skeleton for the exporter. Trying something new in term of architecture with a `struct` (instead of a function) that will own the `Model` and be responsible for the export. The reason is that we discussed a lot of possible parameters to pass to the binary; the `Exporter` is the structure that would also have these parameters.

Note: Putting that PR as a Draft for now. Please tell me what you think of it.