### PR TITLE
[tech] Replace 'failure' with 'thiserror' in 'transit_model_collection'

### DIFF
--- a/collection/Cargo.toml
+++ b/collection/Cargo.toml
@@ -11,5 +11,5 @@ keywords = ["collection", "index"]
 [dependencies]
 derivative = "1.0"
 serde = { version = "1", features = ["derive"] }
-failure = "0.1.5"
 log = "0.4.8"
+thiserror = "1.0"

--- a/collection/src/lib.rs
+++ b/collection/src/lib.rs
@@ -16,7 +16,11 @@
 //! support.
 
 /// The error type used by the crate.
-pub type Error = failure::Error;
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Identifier {0} already exists")]
+    IdentifierAlreadyExists(String),
+}
 
 /// The corresponding result type used by the crate.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/netex_idf/offers.rs
+++ b/src/netex_idf/offers.rs
@@ -440,7 +440,7 @@ fn update_validity_period_from_netex_idf(
     for dataset in &mut datasets {
         validity_period::update_validity_period(dataset, &validity_period);
     }
-    CollectionWithId::new(datasets)
+    CollectionWithId::new(datasets).map_err(|e| format_err!("{}", e))
 }
 
 fn enhance_with_object_code(

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -26,10 +26,10 @@ use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use transit_model_collection::*;
+use transit_model_collection::{Collection, CollectionWithId, Id, Idx};
 
 impl TryFrom<Stop> for StopArea {
-    type Error = Error;
+    type Error = failure::Error;
     fn try_from(stop: Stop) -> Result<Self> {
         if stop.name.is_empty() {
             warn!("stop_id: {}: for platform stop_name is required", stop.id);
@@ -60,7 +60,7 @@ impl TryFrom<Stop> for StopArea {
 }
 
 impl TryFrom<Stop> for StopPoint {
-    type Error = Error;
+    type Error = failure::Error;
     fn try_from(stop: Stop) -> Result<Self> {
         if stop.name.is_empty() {
             warn!("stop_id: {}: for platform name is required", stop.id);
@@ -96,7 +96,7 @@ impl TryFrom<Stop> for StopPoint {
 }
 
 impl TryFrom<Stop> for StopLocation {
-    type Error = Error;
+    type Error = failure::Error;
     fn try_from(stop: Stop) -> Result<Self> {
         let coord = Coord::from((stop.lon, stop.lat));
 

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -205,7 +205,7 @@ where
     O: for<'de> serde::Deserialize<'de> + Id<O>,
 {
     let vec = read_objects(file_handler, file_name)?;
-    CollectionWithId::new(vec)
+    CollectionWithId::new(vec).map_err(|e| format_err!("{}", e))
 }
 
 pub fn read_opt_collection<H, O>(
@@ -217,7 +217,7 @@ where
     O: for<'de> serde::Deserialize<'de> + Id<O>,
 {
     let vec = read_opt_objects(file_handler, file_name)?;
-    CollectionWithId::new(vec)
+    CollectionWithId::new(vec).map_err(|e| format_err!("{}", e))
 }
 
 #[cfg(test)]

--- a/src/transxchange/read.rs
+++ b/src/transxchange/read.rs
@@ -128,7 +128,7 @@ fn update_validity_period_from_transxchange(
     for dataset in &mut datasets {
         validity_period::update_validity_period(dataset, &service_validity_period);
     }
-    CollectionWithId::new(datasets)
+    CollectionWithId::new(datasets).map_err(|e| format_err!("{}", e))
 }
 
 fn load_network(transxchange: &Element) -> Result<Network> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@
 use crate::objects::Date;
 use chrono::NaiveDate;
 use csv;
-use failure::ResultExt;
+use failure::{format_err, ResultExt};
 use geo_types;
 use log::{debug, error, info};
 use rust_decimal::Decimal;
@@ -338,7 +338,7 @@ where
         .deserialize()
         .collect::<Result<_, _>>()
         .with_context(ctx_from_path!(path))?;
-    CollectionWithId::new(vec)
+    CollectionWithId::new(vec).map_err(|e| format_err!("{}", e))
 }
 
 pub fn make_opt_collection<T>(path: &path::Path, file: &str) -> crate::Result<Collection<T>>

--- a/tests/merge_ntfs.rs
+++ b/tests/merge_ntfs.rs
@@ -27,16 +27,17 @@ use transit_model_collection::CollectionWithId;
 use transit_model_collection::Idx;
 
 #[test]
-#[should_panic(expected = "TGC already found")] // first collision is on contributor id
 fn merge_collections_with_collisions() {
     let mut collections = Collections::default();
     let input_collisions = ["tests/fixtures/ntfs", "tests/fixtures/ntfs"];
-    for input_directory in input_collisions.iter() {
-        let to_append_model = transit_model::ntfs::read(input_directory).unwrap();
-        collections
-            .try_merge(to_append_model.into_collections())
-            .unwrap();
-    }
+    let error_message = input_collisions
+        .into_iter()
+        .map(|input_directory| transit_model::ntfs::read(input_directory).unwrap())
+        .map(|model| collections.try_merge(model.into_collections()))
+        .collect::<Result<(), _>>()
+        .unwrap_err()
+        .to_string();
+    assert_eq!("Identifier TGC already exists", error_message);
 }
 
 #[test]
@@ -364,20 +365,20 @@ fn merge_collections_fares_v2() {
 }
 
 #[test]
-#[should_panic(expected = "ticket.1 already found")]
 fn merge_collections_fares_v2_with_collisions() {
     let mut collections = Collections::default();
     let input_dirs = [
         "tests/fixtures/ntfs",
         "tests/fixtures/merge-ntfs/input_farev2_conflicts",
     ];
-    for input_directory in input_dirs.iter() {
-        let to_append_model = transit_model::ntfs::read(input_directory).unwrap();
-
-        collections
-            .try_merge(to_append_model.into_collections())
-            .unwrap();
-    }
+    let error_message = input_dirs
+        .into_iter()
+        .map(|input_directory| transit_model::ntfs::read(input_directory).unwrap())
+        .map(|model| collections.try_merge(model.into_collections()))
+        .collect::<Result<(), _>>()
+        .unwrap_err()
+        .to_string();
+    assert_eq!("Identifier ticket.1 already exists", error_message);
 }
 
 #[test]


### PR DESCRIPTION
Related to #442, I tried to experiment `thiserror` on the sub-crate `transit_model_collection` for now.