### PR TITLE
[tech] Fix full content comparison in test_utils

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -22,13 +22,17 @@ use std::path;
 use std::path::Path;
 use tempfile::tempdir;
 
-pub fn get_file_content<P: AsRef<Path>>(path: P) -> String {
+pub fn get_file_content<P: AsRef<Path>>(path: P) -> Vec<String> {
     let path = path.as_ref();
-    let mut output_file = File::open(path).unwrap_or_else(|_| panic!("file {:?} not found", path));
-    let mut output_contents = String::new();
-    output_file.read_to_string(&mut output_contents).unwrap();
-
-    output_contents
+    let file = File::open(path).unwrap_or_else(|_| panic!("file {:?} not found", path));
+    let reader = BufReader::new(file);
+    let mut vec = Vec::new();
+    for result_line in reader.lines() {
+        let line =
+            result_line.unwrap_or_else(|_| panic!("Cannot parse as a line in file {:?}", path));
+        vec.push(line);
+    }
+    vec
 }
 pub fn get_lines_content<P: AsRef<Path>>(path: P) -> BTreeSet<String> {
     let path = path.as_ref();
@@ -94,7 +98,7 @@ pub fn compare_output_dir_with_expected_content<P: AsRef<Path>>(
         let expected_file_path = format!("{}/{}", work_dir_expected, filename);
         let expected_contents = get_file_content(expected_file_path);
 
-        assert_eq!(expected_contents.trim(), output_contents.trim());
+        assert_eq!(expected_contents, output_contents);
     }
 }
 


### PR DESCRIPTION
An attempt to fix 2 problems with the XML comparison test utils. First of all, as you can see below, the diff from `pretty_assertions` does color the difference but it is just a huge green `String`. Separation per line would be helpful.

![ugly-diff](https://user-images.githubusercontent.com/2520723/73463135-0dd11280-437d-11ea-92ae-5377c0e15391.png)

On top of that, the XML file we're dealing with in `transit_model` are relatively big, and therefore, comparing 2 `String` that huge is quiet process intensive. The result is:
- when the test pass, the result appears right away
- when the test fails, the result might take a few dozen of seconds before generating the colored diff to print

What I changed here is to do a difference line by line. Here is what it would look like.

![nice-diff](https://user-images.githubusercontent.com/2520723/73463131-0c074f00-437d-11ea-997a-51d8675f02b3.png)
