### PR TITLE
[feature] FilterNtfs: filter by line_code

### DIFF
--- a/src/minidom_utils/mod.rs
+++ b/src/minidom_utils/mod.rs
@@ -19,5 +19,7 @@ mod try_attribute;
 pub use try_attribute::TryAttribute;
 mod try_only_child;
 pub use try_only_child::TryOnlyChild;
+#[cfg(feature = "proj")]
 mod writer;
+#[cfg(feature = "proj")]
 pub use self::writer::ElementWriter;

--- a/src/ntfs/filter.rs
+++ b/src/ntfs/filter.rs
@@ -17,75 +17,181 @@
 //! [NTFS](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md).
 
 use crate::{objects::VehicleJourney, Model, Result};
-use failure::bail;
+use failure::{bail, format_err};
+use lazy_static::lazy_static;
 use std::collections::{HashMap, HashSet};
-use transit_model_collection::{CollectionWithId, Idx};
+use transit_model_collection::{CollectionWithId, Id, Idx};
+use transit_model_relations::IdxSet;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Action {
     Extract,
     Remove,
 }
 
-/// Extract or remove networks
-pub fn filter(model: Model, action: Action, network_ids: Vec<String>) -> Result<Model> {
-    fn updated_stop_time_attributes<T>(
-        vehicle_journeys: &CollectionWithId<VehicleJourney>,
-        attributes_map: &HashMap<(Idx<VehicleJourney>, u32), T>,
-        old_vj_idx_to_vj_id: &HashMap<Idx<VehicleJourney>, String>,
-    ) -> HashMap<(Idx<VehicleJourney>, u32), T>
-    where
-        T: Clone,
-    {
-        let mut updated_attributes_map = HashMap::new();
-        for (&(old_vj_idx, sequence), attribute) in attributes_map {
-            if let Some(new_vj_idx) = old_vj_idx_to_vj_id
-                .get(&old_vj_idx)
-                .and_then(|vj_id| vehicle_journeys.get_idx(vj_id))
-            {
-                updated_attributes_map.insert((new_vj_idx, sequence), attribute.clone());
-            }
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+pub enum ObjectType {
+    Network,
+    Line,
+}
+
+type PropertyValues = HashMap<String, HashSet<String>>;
+
+#[derive(Debug)]
+pub struct Filter {
+    action: Action,
+    filters: HashMap<ObjectType, PropertyValues>,
+}
+
+impl Filter {
+    pub fn new(action: Action) -> Self {
+        Filter {
+            action,
+            filters: HashMap::new(),
         }
-        updated_attributes_map
     }
 
-    let mut networks = model.networks.clone();
-    let n_id_to_old_idx = networks.get_id_to_idx().clone();
-    let calendars = model.calendars.clone();
-    let vjs = model.vehicle_journeys.clone();
-    let old_vj_idx_to_vj_id: HashMap<Idx<VehicleJourney>, String> = model
+    pub fn add<T: Into<String>, U: Into<String>>(
+        &mut self,
+        object_type: ObjectType,
+        property: T,
+        value: U,
+    ) {
+        let props = self.filters.entry(object_type).or_insert_with(HashMap::new);
+        props
+            .entry(property.into())
+            .or_insert_with(HashSet::new)
+            .insert(value.into());
+    }
+}
+
+type FnFilter = Box<dyn Fn(&Model, &str) -> Result<IdxSet<VehicleJourney>> + Send + Sync>;
+lazy_static! {
+    static ref PROPERTY_FILTERS: HashMap<ObjectType, HashMap<&'static str, FnFilter>> = {
+        let mut m: HashMap<ObjectType, HashMap<&'static str, FnFilter>> = HashMap::new();
+
+        // Network filters
+        let mut network_filters: HashMap<&'static str, FnFilter> = HashMap::new();
+        network_filters.insert(
+            "network_id",
+            Box::new(|model, network_id| {
+                model
+                    .networks
+                    .get_idx(&network_id)
+                    .ok_or_else(|| format_err!("Network '{}' not found.", network_id))
+                    .map(|network_idx| model.get_corresponding_from_idx(network_idx))
+            }),
+        );
+        m.insert(ObjectType::Network, network_filters);
+
+        // Line filters
+        let mut line_filters: HashMap<&'static str, FnFilter> = HashMap::new();
+        line_filters.insert("line_code",
+            Box::new(|model, line_code| {
+                Ok(model
+                    .lines
+                    .values()
+                    .filter(|line| line.code.as_ref().map(|line_code| line_code.as_str()) == Some(line_code))
+                    // Unwrap is safe because we're iterating on model.lines already
+                    .map(|line| model.lines.get_idx(&line.id).unwrap())
+                    .flat_map(|line_idx| model.get_corresponding_from_idx(line_idx))
+                    .collect())
+            }),
+        );
+        m.insert(ObjectType::Line, line_filters);
+        m
+    };
+}
+
+fn filter_by_property(
+    model: &Model,
+    object_type: ObjectType,
+    property: &str,
+    value: &str,
+) -> Result<IdxSet<VehicleJourney>> {
+    let filter_function = PROPERTY_FILTERS
+        .get(&object_type)
+        .ok_or_else(|| format_err!("Object of type '{:?}' are not yet supported", object_type))?
+        .get(property)
+        .ok_or_else(|| format_err!("Property '{}' not yet supported.", property))?;
+    filter_function(model, value)
+}
+
+fn filter_from_idxset<T: Id<T>>(
+    collection: &mut CollectionWithId<T>,
+    idx_set: IdxSet<T>,
+    action: Action,
+) {
+    let ids: Vec<String> = idx_set
+        .into_iter()
+        .map(|idx| collection[idx].id().to_string())
+        .collect();
+    let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+    collection.retain(|object| match action {
+        Action::Extract => id_refs.contains(&object.id()),
+        Action::Remove => !id_refs.contains(&object.id()),
+    });
+}
+
+fn updated_stop_time_attributes<T>(
+    vehicle_journeys: &CollectionWithId<VehicleJourney>,
+    attributes_map: &HashMap<(Idx<VehicleJourney>, u32), T>,
+    old_vj_idx_to_vj_id: &HashMap<Idx<VehicleJourney>, String>,
+) -> HashMap<(Idx<VehicleJourney>, u32), T>
+where
+    T: Clone,
+{
+    let mut updated_attributes_map = HashMap::new();
+    for (&(old_vj_idx, sequence), attribute) in attributes_map {
+        if let Some(new_vj_idx) = old_vj_idx_to_vj_id
+            .get(&old_vj_idx)
+            .and_then(|vj_id| vehicle_journeys.get_idx(vj_id))
+        {
+            updated_attributes_map.insert((new_vj_idx, sequence), attribute.clone());
+        }
+    }
+    updated_attributes_map
+}
+
+/// Extract or remove part of the dataset from property filters on an object (Network, Line, etc.)
+pub fn filter(model: Model, filter: &Filter) -> Result<Model> {
+    let selected_vjs = filter
+        .filters
+        .iter()
+        .flat_map(|(object_type, property_values)| {
+            property_values
+                .iter()
+                .map(move |(property, values)| (object_type, property, values))
+        })
+        .flat_map(|(object_type, property, values)| {
+            values
+                .iter()
+                .map(move |value| (object_type, property, value))
+        })
+        .map(|(object_type, property, value)| {
+            filter_by_property(&model, *object_type, property.as_str(), value.as_str())
+        })
+        .try_fold::<_, _, Result<IdxSet<VehicleJourney>>>(
+            IdxSet::new(),
+            |mut vehicle_journeys_indexes, idx_set| {
+                vehicle_journeys_indexes.extend(idx_set?);
+                Ok(vehicle_journeys_indexes)
+            },
+        )?;
+
+    let mut collections = model.into_collections();
+    let old_vj_idx_to_vj_id: HashMap<Idx<VehicleJourney>, String> = collections
         .vehicle_journeys
         .get_id_to_idx()
         .iter()
         .map(|(id, &idx)| (idx, id.clone()))
         .collect();
 
-    let network_ids: HashSet<String> = network_ids
-        .into_iter()
-        .map(|id| match networks.get(&id) {
-            Some(_) => Ok(id),
-            None => bail!("network {} not found.", id),
-        })
-        .collect::<Result<HashSet<String>>>()?;
-
-    match action {
-        Action::Extract => networks.retain(|n| network_ids.contains(&n.id)),
-        Action::Remove => networks.retain(|n| !network_ids.contains(&n.id)),
-    }
-
-    let network_idx = networks.values().map(|n| n_id_to_old_idx[&n.id]).collect();
-    let calendars_used = model.get_corresponding(&network_idx);
-    let vjs_used = model.get_corresponding(&network_idx);
-
-    let mut collections = model.into_collections();
-
-    collections
-        .calendars
-        .retain(|c| calendars_used.contains(&calendars.get_idx(&c.id).unwrap()));
-
-    collections
-        .vehicle_journeys
-        .retain(|c| vjs_used.contains(&vjs.get_idx(&c.id).unwrap()));
+    filter_from_idxset(
+        &mut collections.vehicle_journeys,
+        selected_vjs,
+        filter.action,
+    );
 
     collections.stop_time_ids = updated_stop_time_attributes(
         &collections.vehicle_journeys,
@@ -103,8 +209,8 @@ pub fn filter(model: Model, action: Action, network_ids: Vec<String>) -> Result<
         &old_vj_idx_to_vj_id,
     );
 
-    if collections.calendars.is_empty() {
-        bail!("the data does not contain services anymore.")
+    if collections.vehicle_journeys.is_empty() {
+        bail!("the data does not contain vehicle journeys anymore.")
     }
 
     Model::new(collections)

--- a/tests/filter_ntfs.rs
+++ b/tests/filter_ntfs.rs
@@ -21,12 +21,10 @@ fn test_extract_network() {
     test_in_tmp_dir(|path| {
         let input_dir = "tests/fixtures/filter_ntfs/input";
 
-        let model = filter::filter(
-            transit_model::ntfs::read(input_dir).unwrap(),
-            filter::Action::Extract,
-            vec!["network1".into()],
-        )
-        .unwrap();
+        let mut filter = filter::Filter::new(filter::Action::Extract);
+        filter.add(filter::ObjectType::Network, "network_id", "network1");
+
+        let model = filter::filter(transit_model::ntfs::read(input_dir).unwrap(), &filter).unwrap();
         transit_model::ntfs::write(&model, path, get_test_datetime()).unwrap();
         compare_output_dir_with_expected(
             &path,
@@ -41,37 +39,69 @@ fn test_remove_network() {
     test_in_tmp_dir(|path| {
         let input_dir = "tests/fixtures/filter_ntfs/input";
 
-        let model = filter::filter(
-            transit_model::ntfs::read(input_dir).unwrap(),
-            filter::Action::Remove,
-            vec!["network1".into()],
-        )
-        .unwrap();
+        let mut filter = filter::Filter::new(filter::Action::Remove);
+        filter.add(filter::ObjectType::Network, "network_id", "network1");
+
+        let model = filter::filter(transit_model::ntfs::read(input_dir).unwrap(), &filter).unwrap();
         transit_model::ntfs::write(&model, path, get_test_datetime()).unwrap();
         compare_output_dir_with_expected(&path, None, "./tests/fixtures/filter_ntfs/output_remove");
     });
 }
 
 #[test]
-#[should_panic(expected = "network unknown not found.")]
+#[should_panic(expected = "Network \\'unknown\\' not found.")]
 fn test_extract_with_unknown_network() {
     let input_dir = "tests/fixtures/filter_ntfs/input";
-    filter::filter(
-        transit_model::ntfs::read(input_dir).unwrap(),
-        filter::Action::Extract,
-        vec!["unknown".into()],
-    )
-    .unwrap();
+    let mut filter = filter::Filter::new(filter::Action::Extract);
+    filter.add(filter::ObjectType::Network, "network_id", "unknown");
+
+    filter::filter(transit_model::ntfs::read(input_dir).unwrap(), &filter).unwrap();
 }
 
 #[test]
-#[should_panic(expected = "the data does not contain services anymore.")]
+#[should_panic(expected = "the data does not contain vehicle journeys anymore.")]
 fn test_remove_all_networks() {
     let input_dir = "tests/fixtures/filter_ntfs/input";
-    filter::filter(
-        transit_model::ntfs::read(input_dir).unwrap(),
-        filter::Action::Remove,
-        vec!["network1".into(), "network2".into(), "network3".into()],
-    )
-    .unwrap();
+    let mut filter = filter::Filter::new(filter::Action::Remove);
+    filter.add(filter::ObjectType::Network, "network_id", "network1");
+    filter.add(filter::ObjectType::Network, "network_id", "network2");
+    filter.add(filter::ObjectType::Network, "network_id", "network3");
+    filter::filter(transit_model::ntfs::read(input_dir).unwrap(), &filter).unwrap();
+}
+
+#[test]
+fn test_remove_line_by_line_code() {
+    test_in_tmp_dir(|path| {
+        let input_dir = "tests/fixtures/filter_ntfs/input";
+
+        let mut filter = filter::Filter::new(filter::Action::Remove);
+        filter.add(filter::ObjectType::Line, "line_code", "route3");
+
+        let model = filter::filter(transit_model::ntfs::read(input_dir).unwrap(), &filter).unwrap();
+        transit_model::ntfs::write(&model, path, get_test_datetime()).unwrap();
+        compare_output_dir_with_expected(
+            &path,
+            None,
+            "./tests/fixtures/filter_ntfs/output_remove_line",
+        );
+    });
+}
+
+#[test]
+fn test_extract_multiple_line_by_line_code() {
+    test_in_tmp_dir(|path| {
+        let input_dir = "tests/fixtures/filter_ntfs/input";
+
+        let mut filter = filter::Filter::new(filter::Action::Extract);
+        filter.add(filter::ObjectType::Line, "line_code", "route1");
+        filter.add(filter::ObjectType::Line, "line_code", "route3");
+
+        let model = filter::filter(transit_model::ntfs::read(input_dir).unwrap(), &filter).unwrap();
+        transit_model::ntfs::write(&model, path, get_test_datetime()).unwrap();
+        compare_output_dir_with_expected(
+            &path,
+            None,
+            "./tests/fixtures/filter_ntfs/output_extract_multiple_lines",
+        );
+    });
 }

--- a/tests/fixtures/filter_ntfs/input/lines.txt
+++ b/tests/fixtures/filter_ntfs/input/lines.txt
@@ -1,4 +1,4 @@
-line_id,line_name,network_id,commercial_mode_id
-line1,line1,network1,Bus
-line2,line2,network2,Bus
-line3,line3,network3,Bus
+line_id,line_name,network_id,commercial_mode_id,line_code
+line1,line1,network1,Bus,route1
+line2,line2,network2,Bus,route2
+line3,line3,network3,Bus,route3

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/calendar.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/calendar.txt
@@ -1,0 +1,4 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service1,0,1,1,0,0,0,0,20190101,20190102
+service2,0,0,0,1,1,0,0,20190103,20190104
+service3,0,0,0,0,0,1,1,20190105,20190106

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/commercial_modes.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/commercial_modes.txt
@@ -1,0 +1,2 @@
+commercial_mode_id,commercial_mode_name
+Bus,Bus

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/companies.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/companies.txt
@@ -1,0 +1,3 @@
+company_id,company_name,company_address,company_url,company_mail,company_phone
+network1,network1,,,,
+network3,network3,,,,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/contributors.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/contributors.txt
@@ -1,0 +1,2 @@
+contributor_id,contributor_name,contributor_license,contributor_website
+contributor1,Default contributor,Unknown license,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/datasets.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/datasets.txt
@@ -1,0 +1,2 @@
+dataset_id,contributor_id,dataset_start_date,dataset_end_date,dataset_type,dataset_extrapolation,dataset_desc,dataset_system
+dataset1,contributor1,20190101,20190106,,0,,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/feed_infos.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/feed_infos.txt
@@ -1,0 +1,6 @@
+feed_info_param,feed_info_value
+feed_creation_date,20190403
+feed_creation_time,17:19:00
+feed_end_date,20190106
+feed_start_date,20190101
+ntfs_version,0.11.1

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/lines.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/lines.txt
@@ -1,2 +1,3 @@
 line_id,line_code,line_name,forward_line_name,backward_line_name,line_color,line_text_color,line_sort_order,network_id,commercial_mode_id,geometry_id,line_opening_time,line_closing_time
 line1,route1,line1,,,,,,network1,Bus,,,
+line3,route3,line3,,,,,,network3,Bus,,,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/networks.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/networks.txt
@@ -1,0 +1,3 @@
+network_id,network_name,network_url,network_timezone,network_lang,network_phone,network_address,network_sort_order
+network1,network1,,,,,,
+network3,network3,,,,,,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/physical_modes.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/physical_modes.txt
@@ -1,0 +1,5 @@
+physical_mode_id,physical_mode_name,co2_emission
+Bus,Bus,132.0
+Bike,Bike,0.0
+BikeSharingService,BikeSharingService,0.0
+Car,Car,184.0

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/routes.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/routes.txt
@@ -1,0 +1,3 @@
+route_id,route_name,direction_type,line_id,geometry_id,destination_id
+route1,route1,,line1,,
+route3,route3,,line3,,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/stop_times.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/stop_times.txt
@@ -1,0 +1,7 @@
+stop_id,trip_id,stop_sequence,arrival_time,departure_time,boarding_duration,alighting_duration,pickup_type,drop_off_type,datetime_estimated,local_zone_id,stop_headsign,stop_time_id,stop_time_precision
+stop1,trip1,1,22:41:00,22:41:00,0,0,0,0,0,,,,0
+stop2,trip1,2,22:42:00,22:42:00,0,0,0,0,0,,,,0
+stop1,trip2,1,10:41:00,10:41:00,0,0,0,0,0,,,,0
+stop2,trip2,2,10:42:00,10:42:00,0,0,0,0,0,,,,0
+stop1,trip4,1,17:41:00,17:41:00,0,0,0,0,0,,,,0
+stop2,trip4,2,17:42:00,17:42:00,0,0,0,0,0,,,,0

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/stops.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/stops.txt
@@ -1,0 +1,5 @@
+stop_id,stop_name,stop_code,visible,fare_zone_id,stop_lon,stop_lat,location_type,parent_station,stop_timezone,geometry_id,equipment_id,level_id,platform_code
+stop1,stop1,,1,,1.1,2.2,0,Navitia:stop1,,,,,
+stop2,stop2,,1,,1.1,2.2,0,Navitia:stop2,,,,,
+Navitia:stop1,Navitia:stop2,,1,,1.1,2.2,1,,,,,,
+Navitia:stop2,Navitia:stop1,,1,,1.1,2.2,1,,,,,,

--- a/tests/fixtures/filter_ntfs/output_extract_multiple_lines/trips.txt
+++ b/tests/fixtures/filter_ntfs/output_extract_multiple_lines/trips.txt
@@ -1,0 +1,4 @@
+trip_id,route_id,physical_mode_id,dataset_id,service_id,trip_headsign,trip_short_name,block_id,company_id,trip_property_id,geometry_id,journey_pattern_id
+trip1,route1,Bus,dataset1,service1,stop2,,,network1,,,
+trip2,route1,Bus,dataset1,service2,stop2,,,network1,,,
+trip4,route3,Bus,dataset1,service3,stop2,,,network3,,,

--- a/tests/fixtures/filter_ntfs/output_remove/lines.txt
+++ b/tests/fixtures/filter_ntfs/output_remove/lines.txt
@@ -1,3 +1,3 @@
 line_id,line_code,line_name,forward_line_name,backward_line_name,line_color,line_text_color,line_sort_order,network_id,commercial_mode_id,geometry_id,line_opening_time,line_closing_time
-line2,,line2,,,,,,network2,Bus,,,
-line3,,line3,,,,,,network3,Bus,,,
+line2,route2,line2,,,,,,network2,Bus,,,
+line3,route3,line3,,,,,,network3,Bus,,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/calendar.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/calendar.txt
@@ -1,0 +1,3 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service1,0,1,1,0,0,0,0,20190101,20190102
+service2,0,0,0,1,1,0,0,20190103,20190104

--- a/tests/fixtures/filter_ntfs/output_remove_line/comment_links.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/comment_links.txt
@@ -1,0 +1,2 @@
+object_id,object_type,comment_id
+my_stop_time_id,stop_time,my_comment_id

--- a/tests/fixtures/filter_ntfs/output_remove_line/comments.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/comments.txt
@@ -1,0 +1,2 @@
+comment_id,comment_type,comment_label,comment_name,comment_url
+my_comment_id,on_demand_transport,,My comment,

--- a/tests/fixtures/filter_ntfs/output_remove_line/commercial_modes.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/commercial_modes.txt
@@ -1,0 +1,2 @@
+commercial_mode_id,commercial_mode_name
+Bus,Bus

--- a/tests/fixtures/filter_ntfs/output_remove_line/companies.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/companies.txt
@@ -1,0 +1,3 @@
+company_id,company_name,company_address,company_url,company_mail,company_phone
+network1,network1,,,,
+network2,network2,,,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/contributors.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/contributors.txt
@@ -1,0 +1,2 @@
+contributor_id,contributor_name,contributor_license,contributor_website
+contributor1,Default contributor,Unknown license,

--- a/tests/fixtures/filter_ntfs/output_remove_line/datasets.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/datasets.txt
@@ -1,0 +1,2 @@
+dataset_id,contributor_id,dataset_start_date,dataset_end_date,dataset_type,dataset_extrapolation,dataset_desc,dataset_system
+dataset1,contributor1,20190101,20190106,,0,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/feed_infos.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/feed_infos.txt
@@ -1,0 +1,6 @@
+feed_info_param,feed_info_value
+feed_creation_date,20190403
+feed_creation_time,17:19:00
+feed_end_date,20190106
+feed_start_date,20190101
+ntfs_version,0.11.1

--- a/tests/fixtures/filter_ntfs/output_remove_line/lines.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/lines.txt
@@ -1,2 +1,3 @@
 line_id,line_code,line_name,forward_line_name,backward_line_name,line_color,line_text_color,line_sort_order,network_id,commercial_mode_id,geometry_id,line_opening_time,line_closing_time
 line1,route1,line1,,,,,,network1,Bus,,,
+line2,route2,line2,,,,,,network2,Bus,,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/networks.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/networks.txt
@@ -1,0 +1,3 @@
+network_id,network_name,network_url,network_timezone,network_lang,network_phone,network_address,network_sort_order
+network1,network1,,,,,,
+network2,network2,,,,,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/physical_modes.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/physical_modes.txt
@@ -1,0 +1,5 @@
+physical_mode_id,physical_mode_name,co2_emission
+Bus,Bus,132.0
+Bike,Bike,0.0
+BikeSharingService,BikeSharingService,0.0
+Car,Car,184.0

--- a/tests/fixtures/filter_ntfs/output_remove_line/routes.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/routes.txt
@@ -1,0 +1,3 @@
+route_id,route_name,direction_type,line_id,geometry_id,destination_id
+route1,route1,,line1,,
+route2,route2,,line2,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/stop_times.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/stop_times.txt
@@ -1,0 +1,7 @@
+stop_id,trip_id,stop_sequence,arrival_time,departure_time,boarding_duration,alighting_duration,pickup_type,drop_off_type,datetime_estimated,local_zone_id,stop_headsign,stop_time_id,stop_time_precision
+stop1,trip1,1,22:41:00,22:41:00,0,0,0,0,0,,,,0
+stop2,trip1,2,22:42:00,22:42:00,0,0,0,0,0,,,,0
+stop1,trip2,1,10:41:00,10:41:00,0,0,0,0,0,,,,0
+stop2,trip2,2,10:42:00,10:42:00,0,0,0,0,0,,,,0
+stop1,trip3,1,15:41:00,15:41:00,0,0,0,0,0,,,my_stop_time_id,0
+stop2,trip3,2,15:42:00,15:42:00,0,0,0,0,0,,,,0

--- a/tests/fixtures/filter_ntfs/output_remove_line/stops.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/stops.txt
@@ -1,0 +1,5 @@
+stop_id,stop_name,stop_code,visible,fare_zone_id,stop_lon,stop_lat,location_type,parent_station,stop_timezone,geometry_id,equipment_id,level_id,platform_code
+stop1,stop1,,1,,1.1,2.2,0,Navitia:stop1,,,,,
+stop2,stop2,,1,,1.1,2.2,0,Navitia:stop2,,,,,
+Navitia:stop1,Navitia:stop2,,1,,1.1,2.2,1,,,,,,
+Navitia:stop2,Navitia:stop1,,1,,1.1,2.2,1,,,,,,

--- a/tests/fixtures/filter_ntfs/output_remove_line/trips.txt
+++ b/tests/fixtures/filter_ntfs/output_remove_line/trips.txt
@@ -1,0 +1,4 @@
+trip_id,route_id,physical_mode_id,dataset_id,service_id,trip_headsign,trip_short_name,block_id,company_id,trip_property_id,geometry_id,journey_pattern_id
+trip1,route1,Bus,dataset1,service1,stop2,,,network1,,,
+trip2,route1,Bus,dataset1,service2,stop2,,,network1,,,
+trip3,route2,Bus,dataset1,service2,stop2,,,network2,,,


### PR DESCRIPTION
It works but it's ugly.
something like https://github.com/CanalTP/transit_model/compare/master...datanel:wrap_new_filter_ntfs?expand=1 would be better but it does not compile because model that is moved.
