### PR TITLE
[feature] Support StopLocation write by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ members = [
 ]
 
 [features]
-stop_location = []
 xmllint = ["proj"]
 
 [dependencies]

--- a/src/ntfs/write.rs
+++ b/src/ntfs/write.rs
@@ -445,14 +445,6 @@ pub fn write_stops(
     stop_areas: &CollectionWithId<StopArea>,
     stop_locations: &CollectionWithId<StopLocation>,
 ) -> Result<()> {
-    #[cfg(not(feature = "stop_location"))]
-    fn write_stop_locations(
-        _wtr: &mut Writer<File>,
-        _stop_locations: &CollectionWithId<StopLocation>,
-    ) -> Result<()> {
-        Ok(())
-    }
-    #[cfg(feature = "stop_location")]
     fn write_stop_locations(
         wtr: &mut Writer<File>,
         stop_locations: &CollectionWithId<StopLocation>,

--- a/tests/gtfs2ntfs.rs
+++ b/tests/gtfs2ntfs.rs
@@ -150,7 +150,6 @@ fn test_gtfs_with_platforms() {
     });
 }
 
-#[cfg(feature = "stop_location")]
 #[test]
 fn test_gtfs_with_levels() {
     test_in_tmp_dir(|path| {


### PR DESCRIPTION
The test `tests/gtfs2ntfs.rs::test_gtfs_with_levels` is already testing if we're writing correctly the `StopLocation` (type `3`, `4` and `5`).