### PR TITLE
[tech] Fix build of 'transit_model_procmacro

### DIFF
--- a/transit_model_procmacro/Cargo.toml
+++ b/transit_model_procmacro/Cargo.toml
@@ -11,8 +11,8 @@ autotests = false
 proc-macro = true
 
 [dependencies]
-syn = "0.11.11"
-quote = "0.3.15"
+syn = "=0.11.11"
+quote = "=0.3.15"
 
 [dev-dependencies]
 pretty_assertions = "0.6"


### PR DESCRIPTION
The build of `transit_model` is broken on `master` branch. We waited a little bit too long for merging the PR on tests for `procmacro` (#412) and we missed a problem with the new versions of `syn` and/or `quote`: their versions are way too old and we're starting to see problems related to incompatibilities of some libraries using more recent versions. Now that we have tests around this macro, we should be able to upgrade them more safely (still need some complex work though).

This PR should fix the build in the meantime.