### PR TITLE
[tech] Move 'impl_id' inside the 'transit_model_collection' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.org>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.15.2"
+version = "0.15.3"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/collection/Cargo.toml
+++ b/collection/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transit_model_collection"
 description = "Manage collection of objects"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Kisio Digital <team.coretools@kisio.org>"]
 edition = "2018"
 license = "AGPL-3.0-only"

--- a/collection/src/collection.rs
+++ b/collection/src/collection.rs
@@ -42,6 +42,46 @@ pub trait Id<T> {
     fn set_id(&mut self, id: String);
 }
 
+/// Implements the Id trait for an object. For example, if an object Animal has
+/// a field 'species_id' which is a pointer toward another Object of type
+/// Species, you can implements Id with the following example. You can also
+/// implement Id for Animal itself (the identifier of an Animal is it's own
+/// field that must be named `id`).
+/// ```
+/// # #[macro_use]
+/// # extern crate transit_model_collection;
+/// # fn main() {
+/// struct Species {
+///   id: String,
+///   name: String,
+/// }
+/// struct Animal {
+///   id: String,
+///   name: String,
+///   species_id: String,
+/// }
+/// impl_id!(Animal, Species, species_id);
+/// impl_id!(Animal);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! impl_id {
+    ($ty:ty, $gen:ty, $id: ident) => {
+        impl transit_model_collection::Id<$gen> for $ty {
+            fn id(&self) -> &str {
+                &self.$id
+            }
+
+            fn set_id(&mut self, id: std::string::String) {
+                self.$id = id;
+            }
+        }
+    };
+    ($ty:ty) => {
+        impl_id!($ty, $ty, id);
+    };
+}
+
 /// Typed index.
 #[derive(Derivative, Debug)]
 #[derivative(

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -36,7 +36,7 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::result::Result as StdResult;
-use transit_model_collection::{Collection, CollectionWithId, Id};
+use transit_model_collection::{Collection, CollectionWithId};
 
 fn default_agency_id() -> String {
     1.to_string()
@@ -1217,6 +1217,7 @@ mod tests {
     };
     use geo_types::line_string;
     use pretty_assertions::assert_eq;
+    use transit_model_collection::Id;
 
     fn extract<'a, T, S: ::std::cmp::Ord>(f: fn(&'a T) -> S, c: &'a Collection<T>) -> Vec<S> {
         let mut extracted_props: Vec<S> = c.values().map(|l| f(l)).collect();

--- a/src/kv1/read.rs
+++ b/src/kv1/read.rs
@@ -28,7 +28,7 @@ use proj::Proj;
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::result::Result as StdResult;
-use transit_model_collection::{CollectionWithId, Id};
+use transit_model_collection::CollectionWithId;
 
 /// Deserialize kv1 string date (Y-m-d) to NaiveDate
 fn de_from_date_string<'de, D>(deserializer: D) -> StdResult<Date, D::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@
 #![deny(missing_docs)]
 
 #[macro_use]
+extern crate transit_model_collection;
+
+#[macro_use]
 mod utils;
 mod add_prefix;
 use add_prefix::AddPrefix;

--- a/src/netex_idf/lines.rs
+++ b/src/netex_idf/lines.rs
@@ -31,7 +31,7 @@ use std::{
     fs::File,
     io::Read,
 };
-use transit_model_collection::{CollectionWithId, Id};
+use transit_model_collection::CollectionWithId;
 
 // #000000
 const DEFAULT_COLOR: Rgb = Rgb {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -28,7 +28,7 @@ use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Div, Sub};
 use std::str::FromStr;
-use transit_model_collection::{Id, Idx, WithId};
+use transit_model_collection::{Idx, WithId};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -131,23 +131,6 @@ macro_rules! impl_with_id {
                 r
             }
         }
-    };
-}
-
-macro_rules! impl_id {
-    ($ty:ty, $gen:ty, $id: ident) => {
-        impl Id<$gen> for $ty {
-            fn id(&self) -> &str {
-                &self.$id
-            }
-
-            fn set_id(&mut self, id: String) {
-                self.$id = id;
-            }
-        }
-    };
-    ($ty:ty) => {
-        impl_id!($ty, $ty, id);
     };
 }
 


### PR DESCRIPTION
Waiting for https://github.com/CanalTP/transit_model/pull/571 to be merged in order to fix the build.