### PR TITLE
[tech] Move Availability from 'common_format' to 'objects'

### DIFF
--- a/src/apply_rules/property_rule.rs
+++ b/src/apply_rules/property_rule.rs
@@ -13,9 +13,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    common_format::Availability,
     model::Collections,
-    objects::{Coord, Equipment, Geometry, Line, TripProperty, VehicleJourney},
+    objects::{Availability, Coord, Equipment, Geometry, Line, TripProperty, VehicleJourney},
     utils::{Report, ReportType},
     Result,
 };

--- a/src/common_format.rs
+++ b/src/common_format.rs
@@ -21,25 +21,12 @@ use crate::vptranslator::translate;
 use crate::Result;
 use chrono::{self, Datelike, Weekday};
 use csv;
-use derivative::Derivative;
 use failure::{bail, format_err, ResultExt};
 use log::info;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path;
 use transit_model_collection::*;
-
-#[derive(Serialize, Deserialize, Debug, Derivative, PartialEq, Eq, Hash, Clone, Copy)]
-#[derivative(Default)]
-pub enum Availability {
-    #[derivative(Default)]
-    #[serde(rename = "0")]
-    InformationNotAvailable,
-    #[serde(rename = "1")]
-    Available,
-    #[serde(rename = "2")]
-    NotAvailable,
-}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CalendarDate {

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -18,11 +18,11 @@ mod read;
 mod write;
 
 use crate::{
-    common_format::{manage_calendars, write_calendar_dates, Availability},
+    common_format::{manage_calendars, write_calendar_dates},
     gtfs::read::EquipmentList,
     model::{Collections, Model},
     objects,
-    objects::{StopPoint, StopType, Time},
+    objects::{Availability, StopPoint, StopType, Time},
     read_utils,
     utils::*,
     validity_period, AddPrefix, Result,

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -17,11 +17,10 @@ use super::{
     TransferType, Trip,
 };
 use crate::{
-    common_format::Availability,
     model::Collections,
     objects::{
-        self, CommentLinksT, Coord, KeysValues, Pathway, StopLocation, StopTime as NtfsStopTime,
-        StopTimePrecision, StopType, Time, TransportType, VehicleJourney,
+        self, Availability, CommentLinksT, Coord, KeysValues, Pathway, StopLocation,
+        StopTime as NtfsStopTime, StopTimePrecision, StopType, Time, TransportType, VehicleJourney,
     },
     read_utils::{read_collection, read_objects, FileHandler},
     utils::*,
@@ -2218,33 +2217,34 @@ mod tests {
                 vec![&None, &Some("1".to_string())],
                 extract(|sa| &sa.equipment_id, &stop_areas)
             );
+            use objects::Availability::*;
             assert_eq!(
                 vec![
                     Equipment {
                         id: "0".to_string(),
-                        wheelchair_boarding: common_format::Availability::Available,
-                        sheltered: common_format::Availability::InformationNotAvailable,
-                        elevator: common_format::Availability::InformationNotAvailable,
-                        escalator: common_format::Availability::InformationNotAvailable,
-                        bike_accepted: common_format::Availability::InformationNotAvailable,
-                        bike_depot: common_format::Availability::InformationNotAvailable,
-                        visual_announcement: common_format::Availability::InformationNotAvailable,
-                        audible_announcement: common_format::Availability::InformationNotAvailable,
-                        appropriate_escort: common_format::Availability::InformationNotAvailable,
-                        appropriate_signage: common_format::Availability::InformationNotAvailable,
+                        wheelchair_boarding: Available,
+                        sheltered: InformationNotAvailable,
+                        elevator: InformationNotAvailable,
+                        escalator: InformationNotAvailable,
+                        bike_accepted: InformationNotAvailable,
+                        bike_depot: InformationNotAvailable,
+                        visual_announcement: InformationNotAvailable,
+                        audible_announcement: InformationNotAvailable,
+                        appropriate_escort: InformationNotAvailable,
+                        appropriate_signage: InformationNotAvailable,
                     },
                     Equipment {
                         id: "1".to_string(),
-                        wheelchair_boarding: common_format::Availability::NotAvailable,
-                        sheltered: common_format::Availability::InformationNotAvailable,
-                        elevator: common_format::Availability::InformationNotAvailable,
-                        escalator: common_format::Availability::InformationNotAvailable,
-                        bike_accepted: common_format::Availability::InformationNotAvailable,
-                        bike_depot: common_format::Availability::InformationNotAvailable,
-                        visual_announcement: common_format::Availability::InformationNotAvailable,
-                        audible_announcement: common_format::Availability::InformationNotAvailable,
-                        appropriate_escort: common_format::Availability::InformationNotAvailable,
-                        appropriate_signage: common_format::Availability::InformationNotAvailable,
+                        wheelchair_boarding: NotAvailable,
+                        sheltered: InformationNotAvailable,
+                        elevator: InformationNotAvailable,
+                        escalator: InformationNotAvailable,
+                        bike_accepted: InformationNotAvailable,
+                        bike_depot: InformationNotAvailable,
+                        visual_announcement: InformationNotAvailable,
+                        audible_announcement: InformationNotAvailable,
+                        appropriate_escort: InformationNotAvailable,
+                        appropriate_signage: InformationNotAvailable,
                     },
                 ],
                 equipments_collection.into_vec()
@@ -2281,19 +2281,20 @@ mod tests {
                 stop_point_equipment_ids
             );
 
+            use objects::Availability::*;
             assert_eq!(
                 vec![Equipment {
                     id: "0".to_string(),
-                    wheelchair_boarding: common_format::Availability::Available,
-                    sheltered: common_format::Availability::InformationNotAvailable,
-                    elevator: common_format::Availability::InformationNotAvailable,
-                    escalator: common_format::Availability::InformationNotAvailable,
-                    bike_accepted: common_format::Availability::InformationNotAvailable,
-                    bike_depot: common_format::Availability::InformationNotAvailable,
-                    visual_announcement: common_format::Availability::InformationNotAvailable,
-                    audible_announcement: common_format::Availability::InformationNotAvailable,
-                    appropriate_escort: common_format::Availability::InformationNotAvailable,
-                    appropriate_signage: common_format::Availability::InformationNotAvailable,
+                    wheelchair_boarding: Available,
+                    sheltered: InformationNotAvailable,
+                    elevator: InformationNotAvailable,
+                    escalator: InformationNotAvailable,
+                    bike_accepted: InformationNotAvailable,
+                    bike_depot: InformationNotAvailable,
+                    visual_announcement: InformationNotAvailable,
+                    audible_announcement: InformationNotAvailable,
+                    appropriate_escort: InformationNotAvailable,
+                    appropriate_signage: InformationNotAvailable,
                 }],
                 equipments_collection.into_vec()
             );

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -16,7 +16,6 @@ use super::{
     Agency, DirectionType, Route, RouteType, Shape, Stop, StopLocationType, StopTime, Transfer,
     Trip,
 };
-use crate::common_format::Availability;
 use crate::model::{GetCorresponding, Model};
 use crate::objects;
 use crate::objects::Transfer as NtfsTransfer;

--- a/src/kv1/read.rs
+++ b/src/kv1/read.rs
@@ -13,11 +13,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    common_format::{Availability, CalendarDate},
-    model::Collections,
-    objects::*,
-    read_utils::FileHandler,
-    Result,
+    common_format::CalendarDate, model::Collections, objects::*, read_utils::FileHandler, Result,
 };
 use chrono::NaiveDate;
 use csv;

--- a/src/netex_france/stops.rs
+++ b/src/netex_france/stops.rs
@@ -13,12 +13,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
 use crate::{
-    common_format::Availability,
     netex_france::{
         exporter::{Exporter, ObjectType},
         NetexMode,
     },
-    objects::{Coord, Equipment, StopArea, StopLocation, StopPoint, StopType},
+    objects::{Availability, Coord, Equipment, StopArea, StopLocation, StopPoint, StopType},
     Model, Result,
 };
 use failure::format_err;

--- a/src/netex_idf/accessibility.rs
+++ b/src/netex_idf/accessibility.rs
@@ -12,7 +12,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 
-use crate::{common_format::Availability, minidom_utils::TryOnlyChild};
+use crate::{minidom_utils::TryOnlyChild, objects::Availability};
 use minidom::Element;
 
 #[derive(Eq, PartialEq, Hash, Clone)]

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -319,7 +319,8 @@ mod tests {
     use super::Collections;
     use super::*;
     use super::{read, write};
-    use crate::common_format::{manage_calendars, write_calendar_dates, Availability};
+    use crate::common_format::{manage_calendars, write_calendar_dates};
+    use crate::objects::Availability;
     use crate::{read_utils::PathFileHandler, test_utils::*};
     use geo_types::line_string;
     use pretty_assertions::assert_eq;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -16,7 +16,7 @@
 
 #![allow(missing_docs)]
 
-use crate::{common_format::Availability, utils::*, AddPrefix};
+use crate::{utils::*, AddPrefix};
 use chrono;
 use chrono::NaiveDate;
 use derivative::Derivative;
@@ -1318,6 +1318,18 @@ impl AddPrefix for Comment {
     fn add_prefix(&mut self, prefix: &str) {
         self.id = prefix.to_string() + &self.id;
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Derivative, PartialEq, Eq, Hash, Clone, Copy)]
+#[derivative(Default)]
+pub enum Availability {
+    #[derivative(Default)]
+    #[serde(rename = "0")]
+    InformationNotAvailable,
+    #[serde(rename = "1")]
+    Available,
+    #[serde(rename = "2")]
+    NotAvailable,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Default, Clone)]


### PR DESCRIPTION
Waiting for https://github.com/CanalTP/transit_model/pull/571 to be merged in order to fix the build.