### PR TITLE
[tech] Remove FileHandler from 'kv1' module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ quick-xml = "0.17"
 rust_decimal = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempdir = "0.3"
 tempfile = "3"
 time-parse = "0.1"
 walkdir = "2.1"


### PR DESCRIPTION
Modification of how `kv1::read` works: it uses a `Path` instead of `FileHandler` structure. `read_from_zip()` now unzip all the files into a temporary folder and call `read_from_path()` with this temporary folder.