### PR TITLE
[tech] Replace 'tempdir' with 'tempfile'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ quick-xml = "0.17"
 rust_decimal = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tempdir = "0.3"
 tempfile = "3"
 time-parse = "0.1"
 walkdir = "2.1"

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -25,7 +25,7 @@ use std::{
     io::{Read, Write},
     path::Path,
 };
-use tempdir::TempDir;
+use tempfile::TempDir;
 use transit_model_collection::CollectionWithId;
 
 /// Imports a `Model` from the KV1 files in the `path` directory.
@@ -82,7 +82,7 @@ pub fn read_from_zip<P: AsRef<Path>, Q: AsRef<Path>>(
 ) -> Result<Model> {
     let file = File::open(path.as_ref())?;
     let mut archive = zip::ZipArchive::new(file)?;
-    let unzipped_folder = TempDir::new("transit_model_")?;
+    let unzipped_folder = TempDir::new()?;
     for file_index in 0..archive.len() {
         let mut file = archive.by_index(file_index)?;
         if file.is_file() {


### PR DESCRIPTION
`tempfile` is integrated into the `tempfile` crate (as mentioned in the documentation of `tempdir`). So let's try to remove `tempdir` from our dependencies.