### PR TITLE
[tech] Expose new API validity_period

### DIFF
--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -272,7 +272,7 @@ where
     manage_calendars(file_handler, &mut collections)?;
 
     let (contributor, mut dataset, feed_infos) = read_utils::read_config(config_path)?;
-    validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
+    validity_period::calculate_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
     collections.contributors = CollectionWithId::new(vec![contributor])?;
     collections.datasets = CollectionWithId::new(vec![dataset])?;

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -2698,8 +2698,11 @@ mod tests {
             let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
             common_format::manage_calendars(&mut handler, &mut collections).unwrap();
-            validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)
-                .unwrap();
+            validity_period::calculate_dataset_validity_period(
+                &mut dataset,
+                &collections.calendars,
+            )
+            .unwrap();
 
             assert_eq!(
                 Dataset {
@@ -2730,8 +2733,11 @@ mod tests {
             let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
             common_format::manage_calendars(&mut handler, &mut collections).unwrap();
-            validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)
-                .unwrap();
+            validity_period::calculate_dataset_validity_period(
+                &mut dataset,
+                &collections.calendars,
+            )
+            .unwrap();
 
             assert_eq!(
                 Dataset {

--- a/src/kv1/mod.rs
+++ b/src/kv1/mod.rs
@@ -47,7 +47,7 @@ pub fn read_from_path<P: AsRef<Path>, Q: AsRef<Path>>(
     read::read_operday(&path, &mut collections)?;
 
     let (contributor, mut dataset, feed_infos) = read_utils::read_config(config_path)?;
-    validity_period::set_dataset_validity_period(&mut dataset, &collections.calendars)?;
+    validity_period::calculate_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
     collections.contributors = CollectionWithId::new(vec![contributor])?;
     collections.datasets = CollectionWithId::new(vec![dataset])?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub mod test_utils;
 pub mod transfers;
 #[cfg(feature = "proj")]
 pub mod transxchange;
-mod validity_period;
+pub mod validity_period;
 pub mod vptranslator;
 
 /// Current version of the NTFS format

--- a/src/netex_idf/offers.rs
+++ b/src/netex_idf/offers.rs
@@ -440,7 +440,7 @@ fn update_validity_period_from_netex_idf(
 ) -> Result<CollectionWithId<Dataset>> {
     let mut datasets = datasets.take();
     for dataset in &mut datasets {
-        validity_period::update_validity_period(dataset, &validity_period);
+        validity_period::set_dataset_validity_period(dataset, &validity_period);
     }
     CollectionWithId::new(datasets)
 }

--- a/src/transxchange/read.rs
+++ b/src/transxchange/read.rs
@@ -126,7 +126,7 @@ fn update_validity_period_from_transxchange(
     let service_validity_period = get_service_validity_period(transxchange, max_end_date)?;
     let mut datasets = datasets.take();
     for dataset in &mut datasets {
-        validity_period::update_validity_period(dataset, &service_validity_period);
+        validity_period::set_dataset_validity_period(dataset, &service_validity_period);
     }
     CollectionWithId::new(datasets)
 }

--- a/src/validity_period.rs
+++ b/src/validity_period.rs
@@ -20,7 +20,7 @@ use crate::{
 use std::collections::BTreeSet;
 use transit_model_collection::CollectionWithId;
 
-pub fn get_validity_period(calendars: &CollectionWithId<Calendar>) -> Option<ValidityPeriod> {
+fn get_validity_period(calendars: &CollectionWithId<Calendar>) -> Option<ValidityPeriod> {
     let dates = calendars.values().fold(BTreeSet::new(), |acc, c| {
         acc.union(&c.dates).cloned().collect()
     });
@@ -35,7 +35,8 @@ pub fn get_validity_period(calendars: &CollectionWithId<Calendar>) -> Option<Val
     })
 }
 
-pub fn set_dataset_validity_period(
+/// Define the Validity Period of the dataset from all the available services.
+pub fn calculate_dataset_validity_period(
     dataset: &mut Dataset,
     calendars: &CollectionWithId<Calendar>,
 ) -> Result<()> {
@@ -49,8 +50,14 @@ pub fn set_dataset_validity_period(
     Ok(())
 }
 
-#[cfg(feature = "proj")]
-pub fn update_validity_period(dataset: &mut Dataset, service_validity_period: &ValidityPeriod) {
+/// Set the validity period of a dataset.
+///
+/// Take also a look at the `calculate_dataset_validity_period` function that
+/// can automatically calculate the validity period from the Services dates.
+pub fn set_dataset_validity_period(
+    dataset: &mut Dataset,
+    service_validity_period: &ValidityPeriod,
+) {
     dataset.start_date = if service_validity_period.start_date < dataset.start_date {
         service_validity_period.start_date
     } else {
@@ -66,8 +73,7 @@ pub fn update_validity_period(dataset: &mut Dataset, service_validity_period: &V
 #[cfg(test)]
 mod tests {
 
-    #[cfg(feature = "proj")]
-    mod update_validity_period {
+    mod set_validity_period {
         use super::super::*;
         use crate::objects::{Dataset, Date, ValidityPeriod};
         use chrono::naive::{MAX_DATE, MIN_DATE};
@@ -88,7 +94,7 @@ mod tests {
                 start_date,
                 end_date,
             };
-            update_validity_period(&mut dataset, &service_validity_period);
+            set_dataset_validity_period(&mut dataset, &service_validity_period);
             assert_eq!(start_date, dataset.start_date);
             assert_eq!(end_date, dataset.end_date);
         }
@@ -108,7 +114,7 @@ mod tests {
                 start_date,
                 end_date,
             };
-            update_validity_period(&mut dataset, &service_validity_period);
+            set_dataset_validity_period(&mut dataset, &service_validity_period);
             assert_eq!(start_date, dataset.start_date);
             assert_eq!(end_date, dataset.end_date);
         }
@@ -128,7 +134,7 @@ mod tests {
                 start_date: Date::from_ymd(2019, 3, 1),
                 end_date: Date::from_ymd(2019, 4, 30),
             };
-            update_validity_period(&mut dataset, &service_validity_period);
+            set_dataset_validity_period(&mut dataset, &service_validity_period);
             assert_eq!(start_date, dataset.start_date);
             assert_eq!(end_date, dataset.end_date);
         }


### PR DESCRIPTION
I've modified the name of the methods:
- `set_dataset_validity_period()` into `calculate_dataset_validity_period()` because it does calculate a validity period out of the list of `Calendar`
- `update_validity_period()` into... `set_dataset_validity_period()` because it takes a mutable `Dataset` and a `ValidityPeriod` and set it, just like that!