### PR TITLE
[tech] Replace 'ignore' by 'text' for JSON documentation

### DIFF
--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -45,7 +45,7 @@ struct Config {
 /// - a Dataset
 /// - a list of key/value which will be used in 'feed_infos.txt'
 /// Below is an example of this file
-/// ```ignore
+/// ```text
 /// {
 ///     "contributor": {
 ///         "contributor_id": "contributor_id",


### PR DESCRIPTION
Every time we run test, this block of documentation is considered as a test, but ignored. But in reality, this is only some documentation block, not even Rust code. The `text` is more appropriate than `ignore`.