### PR TITLE
[feature] Expose publicly 'calendars' (fixes #582)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod utils;
 mod add_prefix;
 pub use add_prefix::AddPrefix;
 pub mod apply_rules;
-mod calendars;
+pub mod calendars;
 #[macro_use]
 pub mod objects;
 pub mod gtfs;


### PR DESCRIPTION
Follow up of the PR https://github.com/CanalTP/transit_model/pull/582.