### PR TITLE
[fix] Fix the auto-publish Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,20 @@ on:
   release:
     types: [created]
 
+env:
+  PROJ_VERSION: 6.3.0
+
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
     steps:
+    - name: Install proj
+      run: |
+        wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | sudo apt-key add -
+        echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" | sudo tee /etc/apt/sources.list.d/kisio-digital.list
+        sudo apt update
+        sudo apt install --yes pkg-config libssl-dev clang proj=${PROJ_VERSION}
     - uses: actions/checkout@master
     - name: Install Rust
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The current `publish` workflow can't work because the compilation (done during publishing) needs `proj`. ~Also, I believe the tests are ran during publish so `xmllint` must be installed as well as NeTEx submodules checkout.~ The tests are [not done during publish](https://doc.rust-lang.org/cargo/reference/publishing.html#packaging-a-crate), removing checkout of submodules and installation of package `libxml2-utils`.