### PR TITLE
[tech] Update minidom to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.16.2"
+version = "0.17.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"
@@ -36,7 +36,7 @@ iso4217 = "0.3"
 lazy_static = "1.2"
 log = "0.4"
 md5 = "0.7"
-minidom = "0.11"
+minidom = "0.12"
 minidom_ext = "1"
 num-traits = "0.2"
 pretty_assertions = "0.6"


### PR DESCRIPTION
The PR https://github.com/CanalTP/minidom_ext/pull/4 broke the `master` branch of `transit_model`.