### PR TITLE
[lint] Fix some clippy warnings on Cargo manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --workspace --all-features --all-targets -- -D warnings
+        args: --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
 
   tests:
     name: Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"
 keywords = ["ntfs", "gtfs", "netex", "navitia", "transit"]
+categories = ["data-structures", "encoding", "parser-implementations"]
 edition = "2018"
+readme = "README.md"
 exclude = [
 	".gitignore",
 	".mergify.yml",

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from GTFS format to NeTEx France"
 edition = "2018"
+repository = "https://github.com/CanalTP/transit_model"
 homepage = "https://github.com/CanalTP/transit_model"
 readme = "README.md"
 categories = ["command-line-utilities", "data-structures", "encoding", "parser-implementations"]

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from GTFS format to NTFS"
 edition = "2018"
+repository = "https://github.com/CanalTP/transit_model"
 homepage = "https://github.com/CanalTP/transit_model"
 readme = "README.md"
 categories = ["command-line-utilities", "data-structures", "encoding", "parser-implementations"]

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from NTFS format to GTFS"
 edition = "2018"
+repository = "https://github.com/CanalTP/transit_model"
 homepage = "https://github.com/CanalTP/transit_model"
 readme = "README.md"
 categories = ["command-line-utilities", "data-structures", "encoding", "parser-implementations"]

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from NTFS format to NeTEx France"
 edition = "2018"
+repository = "https://github.com/CanalTP/transit_model"
 homepage = "https://github.com/CanalTP/transit_model"
 readme = "README.md"
 categories = ["command-line-utilities", "data-structures", "encoding", "parser-implementations"]

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to check and clean a NTFS"
 edition = "2018"
+repository = "https://github.com/CanalTP/transit_model"
 homepage = "https://github.com/CanalTP/transit_model"
 readme = "README.md"
 categories = ["command-line-utilities", "data-structures", "encoding", "parser-implementations"]


### PR DESCRIPTION
`clippy::cargo` is not enabled by default but can provide some useful hints on  `Cargo.toml` manifests. However, there is no easy way to solve the problem of multiple versions of dependencies so I specifically deactivated this one.