### PR TITLE
[ci] Update pull_request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: Continuous Integration
-on: [push, pull_request]
+on:
+  push
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
 env:
   PROJ_VERSION: 6.3.0


### PR DESCRIPTION
CI is not launched after a merge to recheck other PR in progress

https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
`Note: By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword.`

Attempt to improve