### PR TITLE
Revert "[tech] use of ids instead of indexes for stop_times optional fields"

### DIFF
--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -410,10 +410,7 @@ where
         // consume the stop headsign
         let headsign = std::mem::replace(&mut stop_time.stop_headsign, None);
         if let Some(headsign) = headsign {
-            headsigns.insert(
-                (stop_time.trip_id.clone(), stop_time.stop_sequence),
-                headsign,
-            );
+            headsigns.insert((vj_idx, stop_time.stop_sequence), headsign);
         }
 
         tmp_vjs
@@ -459,7 +456,7 @@ where
                             collections,
                             message,
                             company_idx,
-                            collections.vehicle_journeys[vj_idx].id.clone(),
+                            vj_idx,
                             stop_time,
                         );
                     }
@@ -615,11 +612,11 @@ fn manage_odt_comment_from_stop_time(
     collections: &mut Collections,
     on_demand_transport_comment: &str,
     company_idx: Idx<objects::Company>,
-    vj_id: String,
+    vj_idx: Idx<objects::VehicleJourney>,
     stop_time: &StopTime,
 ) {
     let comment_id = format!("ODT:{}", collections.companies[company_idx].id);
-    collections
+    let comment_idx = collections
         .comments
         .get_idx(&comment_id)
         .unwrap_or_else(|| {
@@ -642,11 +639,11 @@ fn manage_odt_comment_from_stop_time(
         });
     collections
         .stop_time_comments
-        .insert((vj_id.to_string(), stop_time.stop_sequence), comment_id);
+        .insert((vj_idx, stop_time.stop_sequence), comment_idx);
     let stop_time_id = format!("{}-{}", stop_time.trip_id, stop_time.stop_sequence);
     collections
         .stop_time_ids
-        .insert((vj_id, stop_time.stop_sequence), stop_time_id);
+        .insert((vj_idx, stop_time.stop_sequence), stop_time_id);
 }
 
 #[derive(Default)]

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -446,7 +446,7 @@ pub fn write_stop_times(
     path: &path::Path,
     vehicle_journeys: &CollectionWithId<VehicleJourney>,
     stop_points: &CollectionWithId<StopPoint>,
-    stop_times_headsigns: &HashMap<(String, u32), String>,
+    stop_times_headsigns: &HashMap<(Idx<VehicleJourney>, u32), String>,
 ) -> Result<()> {
     info!("Writing stop_times.txt");
     let stop_times_path = path.join("stop_times.txt");
@@ -464,9 +464,7 @@ pub fn write_stop_times(
                     pickup_type: st.pickup_type,
                     drop_off_type: st.drop_off_type,
                     local_zone_id: st.local_zone_id,
-                    stop_headsign: stop_times_headsigns
-                        .get(&(vehicle_journeys[vj_idx].id.clone(), st.sequence))
-                        .cloned(),
+                    stop_headsign: stop_times_headsigns.get(&(vj_idx, st.sequence)).cloned(),
                     timepoint: !st.datetime_estimated,
                 })
                 .with_context(|_| format!("Error reading {:?}", st_wtr))?;
@@ -1148,7 +1146,10 @@ mod tests {
             journey_pattern_id: Some(String::from("jp:01")),
         });
         let mut stop_times_headsigns = HashMap::new();
-        stop_times_headsigns.insert(("vj:01".to_string(), 1), "somewhere".to_string());
+        stop_times_headsigns.insert(
+            (vehicle_journeys.get_idx("vj:01").unwrap(), 1),
+            "somewhere".to_string(),
+        );
         let tmp_dir = tempdir().expect("create temp dir");
         write_stop_times(
             tmp_dir.path(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -121,14 +121,11 @@ pub struct Collections {
     pub geometries: CollectionWithId<Geometry>,
     pub admin_stations: Collection<AdminStation>,
     #[serde(skip)]
-    //HashMap<vehicle_journey_id, stop_sequence, String>,
-    pub stop_time_headsigns: HashMap<(String, u32), String>,
+    pub stop_time_headsigns: HashMap<(Idx<VehicleJourney>, u32), String>,
     #[serde(skip)]
-    //HashMap<(vehicle_journey_id, stop_sequence), stop_time_id>,
-    pub stop_time_ids: HashMap<(String, u32), String>,
+    pub stop_time_ids: HashMap<(Idx<VehicleJourney>, u32), String>,
     #[serde(skip)]
-    //HashMap<(vehicle_journey_id, stop_sequence), comment_id>
-    pub stop_time_comments: HashMap<(String, u32), String>,
+    pub stop_time_comments: HashMap<(Idx<VehicleJourney>, u32), Idx<Comment>>,
     pub prices_v1: Collection<PriceV1>,
     pub od_fares_v1: Collection<ODFareV1>,
     pub fares_v1: Collection<FareV1>,
@@ -230,6 +227,7 @@ impl Collections {
         physical_modes_used.insert(String::from(BIKE_SHARING_SERVICE_PHYSICAL_MODE));
         physical_modes_used.insert(String::from(CAR_PHYSICAL_MODE));
 
+        let vj_id_to_old_idx = self.vehicle_journeys.get_id_to_idx().clone();
         let comment_id_to_old_idx = self.comments.get_id_to_idx().clone();
         let stop_point_id_to_old_idx = self.stop_points.get_id_to_idx().clone();
 
@@ -427,13 +425,17 @@ impl Collections {
             })
             .collect::<Vec<_>>();
 
+        let vj_idx_to_old_id: HashMap<&Idx<VehicleJourney>, &String> =
+            vj_id_to_old_idx.iter().map(|(id, idx)| (idx, id)).collect();
         comments_used.extend(self.stop_time_comments.iter().filter_map(
-            |((vj_id, _), comment_id)| {
-                if vjs.contains_key(vj_id) {
-                    Some(comment_id.clone())
-                } else {
-                    None
-                }
+            |((old_vj_idx, _), old_comment_idx)| {
+                vj_idx_to_old_id.get(&old_vj_idx).and_then(|&old_vj_id| {
+                    if vjs.contains_key(old_vj_id) {
+                        Some(self.comments[*old_comment_idx].id.clone())
+                    } else {
+                        None
+                    }
+                })
             },
         ));
 
@@ -472,15 +474,22 @@ impl Collections {
         self.vehicle_journeys = CollectionWithId::new(vjs)?;
         self.stop_locations = CollectionWithId::new(stop_locations)?;
 
+        let vj_old_idx_to_new_idx: HashMap<Idx<VehicleJourney>, Idx<VehicleJourney>> = self
+            .vehicle_journeys
+            .iter()
+            .map(|(new_idx, vj)| (vj_id_to_old_idx[&vj.id], new_idx))
+            .collect();
         self.stop_time_comments = self
             .stop_time_comments
             .iter()
-            .filter_map(|((vj_id, seq), comment_id)| {
+            .filter_map(|((old_vj_idx, seq), comment_old_idx)| {
                 match (
-                    vehicle_journeys_used.contains(vj_id),
-                    comments_used.contains(comment_id),
+                    vj_old_idx_to_new_idx.get(old_vj_idx),
+                    comment_old_idx_to_new_idx.get(&comment_old_idx),
                 ) {
-                    (true, true) => Some(((vj_id.clone(), *seq), comment_id.clone())),
+                    (Some(new_vj_idx), Some(new_comment_idx)) => {
+                        Some(((*new_vj_idx, *seq), *new_comment_idx))
+                    }
                     _ => None,
                 }
             })
@@ -488,23 +497,19 @@ impl Collections {
         self.stop_time_ids = self
             .stop_time_ids
             .iter()
-            .filter_map(|((vj_id, seq), stop_time_id)| {
-                if vehicle_journeys_used.contains(vj_id) {
-                    Some(((vj_id.clone(), *seq), stop_time_id.clone()))
-                } else {
-                    None
-                }
+            .filter_map(|((old_vj_id, seq), stop_time_id)| {
+                vj_old_idx_to_new_idx
+                    .get(&old_vj_id)
+                    .map(|new_vj_id| ((*new_vj_id, *seq), stop_time_id.clone()))
             })
             .collect();
         self.stop_time_headsigns = self
             .stop_time_headsigns
             .iter()
-            .filter_map(|((vj_id, seq), headsign)| {
-                if vehicle_journeys_used.contains(vj_id) {
-                    Some(((vj_id.clone(), *seq), headsign.clone()))
-                } else {
-                    None
-                }
+            .filter_map(|((old_vj_id, seq), headsign)| {
+                vj_old_idx_to_new_idx
+                    .get(&old_vj_id)
+                    .map(|new_vj_id| ((*new_vj_id, *seq), headsign.clone()))
             })
             .collect();
         self.grid_rel_calendar_line

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -675,12 +675,18 @@ mod tests {
 
         let mut headsigns = HashMap::new();
         headsigns.insert(
-            ("OIF:87604986-1_11595-1".to_string(), 1),
+            (
+                vehicle_journeys.get_idx("OIF:87604986-1_11595-1").unwrap(),
+                1,
+            ),
             "somewhere".to_string(),
         );
         let mut stop_time_ids = HashMap::new();
         stop_time_ids.insert(
-            ("OIF:87604986-1_11595-1".to_string(), 0),
+            (
+                vehicle_journeys.get_idx("OIF:87604986-1_11595-1").unwrap(),
+                0,
+            ),
             "StopTime:OIF:87604986-1_11595-1:0".to_string(),
         );
 
@@ -1076,9 +1082,15 @@ mod tests {
         });
 
         let mut stop_time_ids = HashMap::new();
-        stop_time_ids.insert((("VJ:1").to_string(), 0), "StopTime:VJ:1:0".to_string());
+        stop_time_ids.insert(
+            (vehicle_journeys.get_idx("VJ:1").unwrap(), 0),
+            "StopTime:VJ:1:0".to_string(),
+        );
         let mut stop_time_comments = HashMap::new();
-        stop_time_comments.insert(("VJ:1".to_string(), 0), "c:2".to_string());
+        stop_time_comments.insert(
+            (vehicle_journeys.get_idx("VJ:1").unwrap(), 0),
+            comments.get_idx("c:2").unwrap(),
+        );
 
         ser_collections.comments = comments;
         ser_collections.stop_areas = stop_areas;

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -287,10 +287,7 @@ pub fn manage_stop_times(collections: &mut Collections, path: &path::Path) -> Re
             })?;
 
         if let Some(headsign) = stop_time.stop_headsign {
-            headsigns.insert(
-                (stop_time.trip_id.clone(), stop_time.stop_sequence),
-                headsign,
-            );
+            headsigns.insert((vj_idx, stop_time.stop_sequence), headsign);
         }
         let datetime_estimated = stop_time.datetime_estimated.map_or_else(
             || match collections.stop_points[stop_point_idx].stop_type {
@@ -309,10 +306,7 @@ pub fn manage_stop_times(collections: &mut Collections, path: &path::Path) -> Re
         });
 
         if let Some(stop_time_id) = stop_time.stop_time_id {
-            stop_time_ids.insert(
-                (stop_time.trip_id.clone(), stop_time.stop_sequence),
-                stop_time_id,
-            );
+            stop_time_ids.insert((vj_idx, stop_time.stop_sequence), stop_time_id);
         }
 
         collections
@@ -463,8 +457,8 @@ where
 }
 
 fn insert_stop_time_comment_link(
-    stop_time_comments: &mut HashMap<(String, u32), String>,
-    stop_time_ids: &HashMap<&String, (String, u32)>,
+    stop_time_comments: &mut HashMap<(Idx<VehicleJourney>, u32), Idx<Comment>>,
+    stop_time_ids: &HashMap<&String, (Idx<VehicleJourney>, u32)>,
     comments: &CollectionWithId<Comment>,
     comment_link: &CommentLink,
 ) -> Result<()> {
@@ -479,14 +473,14 @@ fn insert_stop_time_comment_link(
             return Ok(());
         }
     };
-    match comments.get(&comment_link.comment_id) {
+    let comment_idx = match comments.get_idx(&comment_link.comment_id) {
         Some(comment_idx) => comment_idx,
         None => bail!(
             "comment.txt: comment_id={} not found",
             comment_link.comment_id
         ),
     };
-    stop_time_comments.insert(idx_sequence.clone(), comment_link.comment_id.clone());
+    stop_time_comments.insert(*idx_sequence, comment_idx);
     Ok(())
 }
 
@@ -500,7 +494,7 @@ pub fn manage_comments(collections: &mut Collections, path: &path::Path) -> Resu
             let stop_time_ids = collections
                 .stop_time_ids
                 .iter()
-                .map(|(k, v)| (v, k.clone()))
+                .map(|(k, v)| (v, *k))
                 .collect();
             info!("Reading comment_links.txt");
             for comment_link in rdr.deserialize() {

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -195,8 +195,11 @@ fn ntfs() {
     );
     assert_eq!(None, iter.next());
 
-    let mut stop_time_comments = HashMap::<(String, u32), String>::new();
-    stop_time_comments.insert(("RERAB1".to_string(), 5), "RERACOM1".to_string());
+    let mut stop_time_comments = HashMap::<(Idx<VehicleJourney>, u32), Idx<Comment>>::new();
+    stop_time_comments.insert(
+        (pt_objects.vehicle_journeys.get_idx("RERAB1").unwrap(), 5),
+        pt_objects.comments.get_idx("RERACOM1").unwrap(),
+    );
 
     assert_eq!(stop_time_comments, pt_objects.stop_time_comments);
 }


### PR DESCRIPTION
Reverts CanalTP/transit_model#623