### PR TITLE
[doc] Fix doc build on docs.rs (remove 'proj' feature)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,3 @@ required-features = ["proj"]
 [dev-dependencies]
 approx = "0.3"
 rust_decimal_macros = "1.0"
-
-[package.metadata.docs.rs]
-all-features = true


### PR DESCRIPTION
No configuration defaults to the default features which, in our case is no feature. This should remove the `proj` feature and fix the build of our documentation on `docs.rs` (see https://docs.rs/crate/transit_model/0.17.2/builds/246776).