### PR TITLE
[tech] Introduce ID, headsign and comments inside StopTime

### DIFF
--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -470,8 +470,10 @@ where
                 .index_mut(vj_idx)
                 .stop_times
                 .push(objects::StopTime {
+                    id: None,
                     stop_point_idx,
                     sequence: stop_time.stop_sequence,
+                    headsign: None,
                     arrival_time: st_values.arrival_time,
                     departure_time: st_values.departure_time,
                     boarding_duration: 0,
@@ -481,6 +483,7 @@ where
                     datetime_estimated: st_values.datetime_estimated,
                     local_zone_id: stop_time.local_zone_id,
                     precision,
+                    comment_links: None,
                 });
         }
     }
@@ -1269,8 +1272,10 @@ where
                         .stop_times
                         .iter()
                         .map(|stop_time| NtfsStopTime {
+                            id: None,
                             stop_point_idx: stop_time.stop_point_idx,
                             sequence: stop_time.sequence,
+                            headsign: None,
                             arrival_time: stop_time.arrival_time + start_time - arrival_time_delta,
                             departure_time: stop_time.departure_time + start_time
                                 - arrival_time_delta,
@@ -1281,6 +1286,7 @@ where
                             datetime_estimated,
                             local_zone_id: stop_time.local_zone_id,
                             precision: stop_time.precision.clone(),
+                            comment_links: None,
                         })
                         .collect();
                     start_time = start_time + Time::new(0, 0, frequency.headway_secs);
@@ -2482,8 +2488,10 @@ mod tests {
             assert_eq!(
                 vec![
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:01").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(6, 0, 0),
                         departure_time: Time::new(6, 0, 0),
                         boarding_duration: 0,
@@ -2493,10 +2501,13 @@ mod tests {
                         datetime_estimated: true,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Approximate),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:02").unwrap(),
                         sequence: 2,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -2506,10 +2517,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:03").unwrap(),
                         sequence: 3,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -2519,6 +2533,7 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                 ],
                 collections.vehicle_journeys.into_vec()[0].stop_times
@@ -2568,8 +2583,10 @@ mod tests {
             assert_eq!(
                 vec![
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:01").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(6, 0, 0),
                         departure_time: Time::new(6, 0, 0),
                         boarding_duration: 0,
@@ -2579,10 +2596,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:02").unwrap(),
                         sequence: 2,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -2592,6 +2612,7 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                 ],
                 collections.vehicle_journeys.into_vec()[0].stop_times
@@ -3265,8 +3286,10 @@ mod tests {
             assert_eq!(
                 vec![
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:01").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(6, 0, 0),
                         departure_time: Time::new(6, 0, 0),
                         boarding_duration: 0,
@@ -3276,10 +3299,13 @@ mod tests {
                         datetime_estimated: true,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Estimated),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:02").unwrap(),
                         sequence: 2,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -3289,10 +3315,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:03").unwrap(),
                         sequence: 3,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -3302,6 +3331,7 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                 ],
                 collections.vehicle_journeys.into_vec()[0].stop_times

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -875,8 +875,10 @@ mod tests {
             geometry_id: Some("Geometry:Line:Relation:6883353".to_string()),
             stop_times: vec![
                 objects::StopTime {
+                    id: None,
                     stop_point_idx: sps.get_idx("OIF:SP:36:2085").unwrap(),
                     sequence: 0,
+                    headsign: None,
                     arrival_time: objects::Time::new(14, 40, 0),
                     departure_time: objects::Time::new(14, 40, 0),
                     boarding_duration: 0,
@@ -886,10 +888,13 @@ mod tests {
                     datetime_estimated: false,
                     local_zone_id: None,
                     precision: None,
+                    comment_links: None,
                 },
                 objects::StopTime {
+                    id: None,
                     stop_point_idx: sps.get_idx("OIF:SP:36:2127").unwrap(),
                     sequence: 1,
+                    headsign: None,
                     arrival_time: objects::Time::new(14, 42, 0),
                     departure_time: objects::Time::new(14, 42, 0),
                     boarding_duration: 0,
@@ -899,6 +904,7 @@ mod tests {
                     datetime_estimated: false,
                     local_zone_id: None,
                     precision: None,
+                    comment_links: None,
                 },
             ],
             journey_pattern_id: Some(String::from("OIF:JP:1")),
@@ -1103,8 +1109,10 @@ mod tests {
         });
         let stop_times_vec = vec![
             StopTime {
+                id: None,
                 stop_point_idx: stop_points.get_idx("sp:01").unwrap(),
                 sequence: 1,
+                headsign: None,
                 arrival_time: Time::new(6, 0, 0),
                 departure_time: Time::new(6, 0, 0),
                 boarding_duration: 0,
@@ -1114,10 +1122,13 @@ mod tests {
                 datetime_estimated: false,
                 local_zone_id: None,
                 precision: None,
+                comment_links: None,
             },
             StopTime {
+                id: None,
                 stop_point_idx: stop_points.get_idx("sp:01").unwrap(),
                 sequence: 2,
+                headsign: None,
                 arrival_time: Time::new(6, 6, 27),
                 departure_time: Time::new(6, 6, 27),
                 boarding_duration: 0,
@@ -1127,6 +1138,7 @@ mod tests {
                 datetime_estimated: true,
                 local_zone_id: Some(3),
                 precision: None,
+                comment_links: None,
             },
         ];
         let vehicle_journeys = CollectionWithId::from(VehicleJourney {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1331,8 +1331,10 @@ mod tests {
                 })
                 .unwrap();
             let stop_time = StopTime {
+                id: None,
                 stop_point_idx: collections.stop_points.get_idx("stop_point_id").unwrap(),
                 sequence: 0,
+                headsign: None,
                 arrival_time: Time::new(0, 0, 0),
                 departure_time: Time::new(0, 0, 0),
                 boarding_duration: 0,
@@ -1342,6 +1344,7 @@ mod tests {
                 datetime_estimated: false,
                 local_zone_id: Some(0),
                 precision: None,
+                comment_links: None,
             };
             collections
                 .vehicle_journeys
@@ -1498,8 +1501,10 @@ mod tests {
             collections: &Collections,
         ) -> VehicleJourney {
             let stop_time_at = |stop_point_id: &str| StopTime {
+                id: None,
                 stop_point_idx: collections.stop_points.get_idx(stop_point_id).unwrap(),
                 sequence: 0,
+                headsign: None,
                 arrival_time: Time::new(0, 0, 0),
                 departure_time: Time::new(0, 0, 0),
                 boarding_duration: 0,
@@ -1509,6 +1514,7 @@ mod tests {
                 datetime_estimated: false,
                 local_zone_id: None,
                 precision: None,
+                comment_links: None,
             };
             let stop_times: Vec<_> = stop_point_ids.into_iter().map(stop_time_at).collect();
             VehicleJourney {

--- a/src/netex_france/offer.rs
+++ b/src/netex_france/offer.rs
@@ -799,8 +799,10 @@ mod tests {
             physical_mode_id: String::from("Bus"),
             stop_times: vec![
                 StopTime {
+                    id: None,
                     stop_point_idx: collections.stop_points.get_idx("sp_id_1").unwrap(),
                     sequence: 0,
+                    headsign: None,
                     arrival_time: Time::new(0, 0, 0),
                     departure_time: Time::new(0, 0, 0),
                     boarding_duration: 0,
@@ -810,10 +812,13 @@ mod tests {
                     datetime_estimated: false,
                     local_zone_id: Some(1),
                     precision: Some(StopTimePrecision::Exact),
+                    comment_links: None,
                 },
                 StopTime {
+                    id: None,
                     stop_point_idx: collections.stop_points.get_idx("sp_id_2").unwrap(),
                     sequence: 1,
+                    headsign: None,
                     arrival_time: Time::new(0, 0, 0),
                     departure_time: Time::new(0, 0, 0),
                     boarding_duration: 0,
@@ -823,6 +828,7 @@ mod tests {
                     datetime_estimated: false,
                     local_zone_id: Some(1),
                     precision: Some(StopTimePrecision::Exact),
+                    comment_links: None,
                 },
             ],
             ..Default::default()
@@ -844,8 +850,10 @@ mod tests {
                 physical_mode_id: String::from("Bus"),
                 stop_times: vec![
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp_id_1").unwrap(),
                         sequence: 0,
+                        headsign: None,
                         arrival_time: Time::new(0, 0, 0),
                         departure_time: Time::new(0, 0, 0),
                         boarding_duration: 0,
@@ -855,10 +863,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: Some(1),
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp_id_2").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(0, 0, 0),
                         departure_time: Time::new(0, 0, 0),
                         boarding_duration: 0,
@@ -868,6 +879,7 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: Some(1),
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                 ],
                 ..Default::default()
@@ -900,8 +912,10 @@ mod tests {
                 dataset_id: String::from("dataset_id"),
                 physical_mode_id: String::from("Bus"),
                 stop_times: vec![StopTime {
+                    id: None,
                     stop_point_idx: collections.stop_points.get_idx("sp_id_1").unwrap(),
                     sequence: 0,
+                    headsign: None,
                     arrival_time: Time::new(0, 0, 0),
                     departure_time: Time::new(0, 0, 0),
                     boarding_duration: 0,
@@ -911,6 +925,7 @@ mod tests {
                     datetime_estimated: false,
                     local_zone_id: Some(1),
                     precision: Some(StopTimePrecision::Exact),
+                    comment_links: None,
                 }],
                 ..Default::default()
             })
@@ -948,8 +963,10 @@ mod tests {
                 physical_mode_id: String::from("Bus"),
                 stop_times: vec![
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp_id_1").unwrap(),
                         sequence: 0,
+                        headsign: None,
                         arrival_time: Time::new(0, 0, 0),
                         departure_time: Time::new(0, 0, 0),
                         boarding_duration: 0,
@@ -959,10 +976,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: Some(1),
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp_id_2").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(0, 0, 0),
                         departure_time: Time::new(0, 0, 0),
                         boarding_duration: 0,
@@ -973,6 +993,7 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: Some(1),
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                 ],
                 ..Default::default()

--- a/src/netex_france/route_points.rs
+++ b/src/netex_france/route_points.rs
@@ -108,8 +108,10 @@ mod tests {
             departure_time: Time,
         ) -> StopTime {
             StopTime {
+                id: None,
                 stop_point_idx,
                 sequence,
+                headsign: None,
                 arrival_time: Time::new(0, 0, 0),
                 departure_time,
                 boarding_duration: 0,
@@ -119,6 +121,7 @@ mod tests {
                 datetime_estimated: false,
                 local_zone_id: None,
                 precision: None,
+                comment_links: None,
             }
         }
 

--- a/src/netex_idf/offers.rs
+++ b/src/netex_idf/offers.rs
@@ -733,8 +733,10 @@ fn stop_times(
             };
             let times = arrival_departure_times(tpt)?;
             let stop_time = StopTime {
+                id: None,
                 stop_point_idx,
                 sequence: sequence as u32,
+                headsign: None,
                 arrival_time: times.0,
                 departure_time: times.1,
                 boarding_duration: 0,
@@ -744,6 +746,7 @@ fn stop_times(
                 datetime_estimated: false,
                 local_zone_id,
                 precision: None,
+                comment_links: None,
             };
 
             Ok(stop_time)

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -624,8 +624,10 @@ mod tests {
                 geometry_id: Some("Geometry:Line:Relation:6883353".to_string()),
                 stop_times: vec![
                     StopTime {
+                        id: None,
                         stop_point_idx: stop_points.get_idx("OIF:SP:36:2085").unwrap(),
                         sequence: 0,
+                        headsign: None,
                         arrival_time: Time::new(14, 40, 0),
                         departure_time: Time::new(14, 40, 0),
                         boarding_duration: 0,
@@ -635,10 +637,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     StopTime {
+                        id: None,
                         stop_point_idx: stop_points.get_idx("OIF:SP:36:2127").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(14, 42, 0),
                         departure_time: Time::new(14, 42, 0),
                         boarding_duration: 0,
@@ -648,6 +653,7 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                 ],
                 journey_pattern_id: Some(String::from("OIF:JP:1")),
@@ -1048,8 +1054,10 @@ mod tests {
             trip_property_id: None,
             geometry_id: None,
             stop_times: vec![StopTime {
+                id: None,
                 stop_point_idx: stop_points.get_idx("sp_1").unwrap(),
                 sequence: 0,
+                headsign: None,
                 arrival_time: Time::new(9, 0, 0),
                 departure_time: Time::new(9, 2, 0),
                 boarding_duration: 2,
@@ -1059,6 +1067,7 @@ mod tests {
                 datetime_estimated: false,
                 local_zone_id: None,
                 precision: None,
+                comment_links: None,
             }],
             journey_pattern_id: None,
         });

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -320,8 +320,10 @@ pub fn manage_stop_times(collections: &mut Collections, path: &path::Path) -> Re
             .index_mut(vj_idx)
             .stop_times
             .push(crate::objects::StopTime {
+                id: None,
                 stop_point_idx,
                 sequence: stop_time.stop_sequence,
+                headsign: None,
                 arrival_time: stop_time.arrival_time,
                 departure_time: stop_time.departure_time,
                 boarding_duration: stop_time.boarding_duration,
@@ -331,6 +333,7 @@ pub fn manage_stop_times(collections: &mut Collections, path: &path::Path) -> Re
                 datetime_estimated,
                 local_zone_id: stop_time.local_zone_id,
                 precision,
+                comment_links: None,
             });
     }
     collections.stop_time_headsigns = headsigns;
@@ -815,8 +818,10 @@ mod tests {
             assert_eq!(
                 vec![
                     objects::StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:01").unwrap(),
                         sequence: 1,
+                        headsign: None,
                         arrival_time: Time::new(6, 0, 0),
                         departure_time: Time::new(6, 0, 0),
                         boarding_duration: 0,
@@ -826,10 +831,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     objects::StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:02").unwrap(),
                         sequence: 2,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -839,10 +847,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Approximate),
+                        comment_links: None,
                     },
                     objects::StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:03").unwrap(),
                         sequence: 3,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -852,10 +863,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Estimated),
+                        comment_links: None,
                     },
                     objects::StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:04").unwrap(),
                         sequence: 3,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -865,10 +879,13 @@ mod tests {
                         datetime_estimated: false,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Exact),
+                        comment_links: None,
                     },
                     objects::StopTime {
+                        id: None,
                         stop_point_idx: collections.stop_points.get_idx("sp:05").unwrap(),
                         sequence: 3,
+                        headsign: None,
                         arrival_time: Time::new(6, 6, 27),
                         departure_time: Time::new(6, 6, 27),
                         boarding_duration: 0,
@@ -878,6 +895,7 @@ mod tests {
                         datetime_estimated: true,
                         local_zone_id: None,
                         precision: Some(StopTimePrecision::Estimated),
+                        comment_links: None,
                     },
                 ],
                 collections.vehicle_journeys.into_vec()[0].stop_times

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -803,10 +803,16 @@ impl std::fmt::Display for Time {
     }
 }
 
+// This struct is using Option<Box<String>> instead of Option<String> because
+// Option::<Box<String>>::None is 8 bytes but Option::<String>::None is 24
+// bytes.  For similar reasons, `comment_links` is in an
+// `Option<Box<CommentLinksT>>` instead of a `CommentLinksT`
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct StopTime {
+    pub id: Option<Box<String>>,
     pub stop_point_idx: Idx<StopPoint>,
     pub sequence: u32,
+    pub headsign: Option<Box<String>>,
     pub arrival_time: Time,
     pub departure_time: Time,
     pub boarding_duration: u16,
@@ -816,6 +822,7 @@ pub struct StopTime {
     pub datetime_estimated: bool,
     pub local_zone_id: Option<u16>,
     pub precision: Option<StopTimePrecision>,
+    pub comment_links: Option<Box<CommentLinksT>>,
 }
 
 impl Ord for StopTime {


### PR DESCRIPTION
I'm targetting a `stop-time` branch for now. We'll merge everything once the whole work on `StopTime` is done. It will allow us to split the work in smaller chunks.

This PR is only introducing the fields inside `objects::StopTime`, not filling them for now.

Next steps will be to fix module one by one until we can remove the `HashMap` in `Collections`: `stop_time_ids`, `stop_time_headsigns` and `stop_time_comments`.