### PR TITLE
[feature] Expose Report and ReportType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.18.0"
+version = "0.18.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/apply_rules/complementary_code.rs
+++ b/src/apply_rules/complementary_code.rs
@@ -15,7 +15,7 @@
 use crate::{
     model::Collections,
     objects::Codes,
-    utils::{Report, ReportType},
+    report::{Report, TransitModelReportCategory},
     Result,
 };
 use failure::ResultExt;
@@ -54,7 +54,7 @@ struct ComplementaryCode {
 
 fn read_complementary_code_rules_files<P: AsRef<Path>>(
     rule_files: Vec<P>,
-    report: &mut Report,
+    report: &mut Report<TransitModelReportCategory>,
 ) -> Result<Vec<ComplementaryCode>> {
     info!("Reading complementary code rules.");
     let mut codes = BTreeSet::new();
@@ -70,7 +70,7 @@ fn read_complementary_code_rules_files<P: AsRef<Path>>(
                 Err(e) => {
                     report.add_warning(
                         format!("Error reading {:?}: {}", path.file_name().unwrap(), e),
-                        ReportType::InvalidFile,
+                        TransitModelReportCategory::InvalidFile,
                     );
                     continue;
                 }
@@ -84,7 +84,7 @@ fn read_complementary_code_rules_files<P: AsRef<Path>>(
 fn insert_code<T>(
     collection: &mut CollectionWithId<T>,
     code: ComplementaryCode,
-    report: &mut Report,
+    report: &mut Report<TransitModelReportCategory>,
 ) where
     T: Codes + Id<T>,
 {
@@ -97,7 +97,7 @@ fn insert_code<T>(
                     code.object_type.as_str(),
                     code.object_id
                 ),
-                ReportType::ObjectNotFound,
+                TransitModelReportCategory::ObjectNotFound,
             );
             return;
         }
@@ -109,10 +109,10 @@ fn insert_code<T>(
         .insert((code.object_system, code.object_code));
 }
 
-pub fn apply_rules<P: AsRef<Path>>(
+pub(crate) fn apply_rules<P: AsRef<Path>>(
     rule_files: Vec<P>,
     collections: &mut Collections,
-    mut report: &mut Report,
+    mut report: &mut Report<TransitModelReportCategory>,
 ) -> Result<()> {
     let codes = read_complementary_code_rules_files(rule_files, &mut report)?;
     for code in codes {

--- a/src/apply_rules/mod.rs
+++ b/src/apply_rules/mod.rs
@@ -20,7 +20,7 @@ mod property_rule;
 
 use crate::{
     objects::{Line, VehicleJourney},
-    utils::Report,
+    report::Report,
     Model, Result,
 };
 use log::info;

--- a/src/apply_rules/network_consolidation.rs
+++ b/src/apply_rules/network_consolidation.rs
@@ -15,7 +15,7 @@
 use crate::{
     model::Collections,
     objects::{Line, Network, ObjectType as ModelObjectType},
-    utils::{Report, ReportType},
+    report::{Report, TransitModelReportCategory},
     Result,
 };
 use failure::{bail, format_err};
@@ -55,7 +55,7 @@ fn read_networks_consolidation_file<P: AsRef<Path>>(
 }
 
 fn check_networks_consolidation(
-    report: &mut Report,
+    report: &mut Report<TransitModelReportCategory>,
     networks: &CollectionWithId<Network>,
     networks_consolidation: Vec<NetworkConsolidation>,
 ) -> Result<Vec<NetworkConsolidation>> {
@@ -74,7 +74,7 @@ fn check_networks_consolidation(
                     "The grouped network list is empty for network consolidation \"{}\"",
                     &ntw.network.id
                 ),
-                ReportType::ObjectNotFound,
+                TransitModelReportCategory::ObjectNotFound,
             );
             continue;
         }
@@ -82,7 +82,7 @@ fn check_networks_consolidation(
             if !networks.contains_id(&ntw_grouped) {
                 report.add_error(
                     format!("The grouped network \"{}\" don't exist", ntw_grouped),
-                    ReportType::ObjectNotFound,
+                    TransitModelReportCategory::ObjectNotFound,
                 );
             } else {
                 network_consolidation = true;
@@ -96,7 +96,7 @@ fn check_networks_consolidation(
                     "No network has been consolidated for network \"{}\"",
                     ntw.network.id
                 ),
-                ReportType::ObjectNotFound,
+                TransitModelReportCategory::ObjectNotFound,
             );
         }
     }
@@ -147,11 +147,11 @@ fn update_ticket_use_perimeters(
     }
 }
 
-pub fn apply_rules<P: AsRef<Path>>(
+pub(crate) fn apply_rules<P: AsRef<Path>>(
     networks_consolidation_file: P,
     lines_by_network: &HashMap<String, IdxSet<Line>>,
     mut collections: Collections,
-    mut report: &mut Report,
+    mut report: &mut Report<TransitModelReportCategory>,
 ) -> Result<Collections> {
     let networks_consolidation = read_networks_consolidation_file(networks_consolidation_file)?;
     let networks_consolidation =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod netex_idf;
 mod netex_utils;
 pub mod ntfs;
 pub mod read_utils;
+pub mod report;
 #[doc(hidden)]
 pub mod test_utils;
 pub mod transfers;

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,96 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+
+//! Helpers to create a report for faillible processes.
+use serde::Serialize;
+
+/// Each report record will be categorized with a type implementing this
+/// `ReportCategory` trait.
+pub trait ReportCategory: Serialize + PartialEq {}
+
+/// Type of the report
+#[derive(Debug, Serialize, PartialEq)]
+pub(crate) enum TransitModelReportCategory {
+    // merge stop areas types
+    OnlyOneStopArea,
+    AmbiguousPriorities,
+    NothingToMerge,
+    MissingToMerge,
+    NoMasterPossible,
+    MasterReplaced,
+    // transfers types
+    TransferIntraIgnored,
+    TransferInterIgnored,
+    TransferOnNonExistentStop,
+    TransferOnUnreferencedStop,
+    TransferAlreadyDeclared,
+    // apply rules
+    ObjectNotFound,
+    InvalidFile,
+    UnknownPropertyName,
+    UnknownPropertyValue,
+    MultipleValue,
+    OldPropertyValueDoesNotMatch,
+    GeometryNotValid,
+    NonConvertibleString,
+}
+
+impl ReportCategory for TransitModelReportCategory {}
+
+/// A report record.
+#[derive(Debug, Serialize, PartialEq)]
+struct ReportRow<R: ReportCategory> {
+    category: R,
+    message: String,
+}
+
+/// An report is a list of report records with 2 levels of recording: warnings
+/// and errors.
+#[derive(Debug, Serialize)]
+pub struct Report<R: ReportCategory> {
+    errors: Vec<ReportRow<R>>,
+    warnings: Vec<ReportRow<R>>,
+}
+
+impl<R: ReportCategory> Default for Report<R> {
+    fn default() -> Self {
+        Report {
+            errors: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}
+
+impl<R: ReportCategory> Report<R> {
+    /// Add a warning report record.
+    pub fn add_warning(&mut self, warning: String, warning_type: R) {
+        let report_row = ReportRow {
+            category: warning_type,
+            message: warning,
+        };
+        if !self.warnings.contains(&report_row) {
+            self.warnings.push(report_row);
+        }
+    }
+    /// Add an error report record.
+    pub fn add_error(&mut self, error: String, error_type: R) {
+        let report_row = ReportRow {
+            category: error_type,
+            message: error,
+        };
+        if !self.errors.contains(&report_row) {
+            self.errors.push(report_row);
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,6 @@ use chrono::NaiveDate;
 use failure::{format_err, ResultExt};
 use log::{debug, error, info};
 use rust_decimal::Decimal;
-use serde::Serialize;
 use std::fs;
 use std::io::{Read, Write};
 use std::path;
@@ -408,65 +407,6 @@ where
         .with_context(|_| format!("Error reading {:?}", path))?;
 
     Ok(())
-}
-
-#[derive(Debug, Serialize, PartialEq)]
-pub enum ReportType {
-    // merge stop areas types
-    OnlyOneStopArea,
-    AmbiguousPriorities,
-    NothingToMerge,
-    MissingToMerge,
-    NoMasterPossible,
-    MasterReplaced,
-    // transfers types
-    TransferIntraIgnored,
-    TransferInterIgnored,
-    TransferOnNonExistentStop,
-    TransferOnUnreferencedStop,
-    TransferAlreadyDeclared,
-    // apply-rules types
-    ObjectNotFound,
-    InvalidFile,
-    UnknownPropertyName,
-    UnknownPropertyValue,
-    MultipleValue,
-    OldPropertyValueDoesNotMatch,
-    GeometryNotValid,
-    NonConvertibleString,
-}
-
-#[derive(Debug, Serialize, PartialEq)]
-struct ReportRow {
-    category: ReportType,
-    message: String,
-}
-
-#[derive(Debug, Default, Serialize)]
-pub struct Report {
-    errors: Vec<ReportRow>,
-    warnings: Vec<ReportRow>,
-}
-
-impl Report {
-    pub fn add_warning(&mut self, warning: String, warning_type: ReportType) {
-        let report_row = ReportRow {
-            category: warning_type,
-            message: warning,
-        };
-        if !self.warnings.contains(&report_row) {
-            self.warnings.push(report_row);
-        }
-    }
-    pub fn add_error(&mut self, error: String, error_type: ReportType) {
-        let report_row = ReportRow {
-            category: error_type,
-            message: error,
-        };
-        if !self.errors.contains(&report_row) {
-            self.errors.push(report_row);
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
For moving some part of `transit_model` like `apply_rules` out of `transit_model`, we need to expose `Report` and `ReportType`.  However, some variant enums of `ReportType` are really related to `apply_rules` itself, not to `transit_model`. So I changed `ReportType` into a trait/contract/interface instead of an `enum`. User needs to implement a type that conforms to this contract. I also moved `Report` and `ReportType` into their own module `report`.

See https://github.com/CanalTP/tartare-tools/pull/77 for how this new trait will be used.  In the current PR, one implementation of the new trait `ReportType` is `TransitModelReportType` which is nothing else than the old `enum ReportType`.