### PR TITLE
[doc] no inline html in markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ Integration tests verify that the conversion produces files in accordance with
 the NeTEx specification.
 
 For that, tests are using the tool `xmllint` which can be installed on Debian
-with the package `libxml2-utils`.<br>
+with the package `libxml2-utils`.\
 Tests also depend on NeTEx specification that are imported as a git submodule.
-Therefore, these tests are run only if feature `xmllint` is activated.<br>
+Therefore, these tests are run only if feature `xmllint` is activated.\
 
 To install xmllint and submodules:
 ```sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: AGPL v3.0](https://img.shields.io/github/license/CanalTP/transit_model?color=9873b9&style=flat-square)](./LICENSE)
 
 **`transit_model`** is a Rust crate to manage, convert and enrich transit
-data.<br>
+data.\
 This is done by implementing the [NTFS] model (used in [navitia]).
 
 This repository regroups crates that offer enabler-libraries and binaries to
@@ -31,14 +31,14 @@ Please check documentation attached to each crate:
 Based on [PROJ], the [`proj` crate] allows the transformation of
 localization coordinates.
 
-Some `transit_model`'s crates (see each documentation) use [PROJ].<br>
+Some `transit_model`'s crates (see each documentation) use [PROJ].\
 So it must be installed on the system to compile and use those crates.
 
 ### [PROJ] for binaries
 
 Using the [`proj` crate] requires some system-dependencies installation.
 
-* The version `6.3.0` of [PROJ] is needed (used and tested by maintainers).<br>
+* The version `6.3.0` of [PROJ] is needed (used and tested by maintainers).\
   On Debian systems:
   ```sh
   # Needed only for proj install
@@ -58,7 +58,7 @@ Using the [`proj` crate] requires some system-dependencies installation.
   [PROJ installation instructions](https://github.com/OSGeo/PROJ#installation)
   may help, too.
 
-* Some packages are also needed.<br>
+* Some packages are also needed.\
   On Debian systems:
   ```sh
   apt install -y clang libssl-dev
@@ -68,15 +68,15 @@ Using the [`proj` crate] requires some system-dependencies installation.
 
 [`proj` crate] is a binding to the C library (version `6.3.0`).
 
-[PROJ] is configured as a `feature` of the `transit_model` crate.<br>
+[PROJ] is configured as a `feature` of the `transit_model` crate.\
 So to use it for coding, the `proj` feature must be activated
-(`cargo build --features=proj`).<br>
+(`cargo build --features=proj`).\
 Then specific code should be conditionally enabled with
 `#[cfg(feature="proj")]`.
 
 ## NTFS Level of Support
 
-`transit_model` is supporting most of [NTFS] format.<br>
+`transit_model` is supporting most of [NTFS] format.\
 From the standard, some of the functionalities are not fully supported:
 * No support for Line Groups (files `line_groups.txt` and `line_group_links.txt`).
 * The field `trip_short_name_at_stop` in `stop_times.txt` introduced in version

--- a/documentation/ntfs_to_netex_france_specs.md
+++ b/documentation/ntfs_to_netex_france_specs.md
@@ -114,7 +114,7 @@ A `stop_area` is considered monomodal if all the trips having stop_times referen
 ### Coordinates conversion
 
 The GTFS `stop_lon` and `stop_lat` are specified in WGS84. The coordinates are
-converted to EPSG:2154 (Lambert 93).<br>
+converted to EPSG:2154 (Lambert 93).\
 Example of Netex declaration:
 ><gml:pos srsName="EPSG:2154">662233.0 6861519.0</gml:pos>
 

--- a/gtfs2netexfr/README.md
+++ b/gtfs2netexfr/README.md
@@ -43,8 +43,8 @@ Get more information about the available options with `--help`.
 
 ## Specifications
 
-As NTFS is the pivot format for conversion, [common NTFS rules] is useful.<br>
-For input, see [GTFS to NTFS specifications].<br>
+As NTFS is the pivot format for conversion, [common NTFS rules] is useful.\
+For input, see [GTFS to NTFS specifications].\
 For output, see [NTFS to NeTEx-France specifications].
 
 [common NTFS rules]: ../documentation/common_ntfs_rules.md

--- a/gtfs2ntfs/README.md
+++ b/gtfs2ntfs/README.md
@@ -52,7 +52,7 @@ explained in the [common NTFS rules].
 
 ## Specifications
 
-As NTFS is the pivot format for conversion, [common NTFS rules] is useful.<br>
+As NTFS is the pivot format for conversion, [common NTFS rules] is useful.\
 For input and output, see [GTFS to NTFS specifications].
 
 [common NTFS rules]: ../documentation/common_ntfs_rules.md

--- a/ntfs2gtfs/README.md
+++ b/ntfs2gtfs/README.md
@@ -29,7 +29,7 @@ Get more information about the available options with `--help`.
 
 ## Specifications
 
-As NTFS is the pivot format for conversion, [common NTFS rules] is useful.<br>
+As NTFS is the pivot format for conversion, [common NTFS rules] is useful.\
 For input and output, see [NTFS to GTFS specifications].
 
 [common NTFS rules]: ../documentation/common_ntfs_rules.md

--- a/ntfs2netexfr/README.md
+++ b/ntfs2netexfr/README.md
@@ -43,7 +43,7 @@ Get more information about the available options with `--help`.
 
 ## Specifications
 
-As NTFS is the pivot format for conversion, [common NTFS rules] is useful.<br>
+As NTFS is the pivot format for conversion, [common NTFS rules] is useful.\
 For input and output, see [NTFS to NeTEx-France specifications].
 
 [common NTFS rules]: ../documentation/common_ntfs_rules.md


### PR DESCRIPTION
- replaced `<br>` by `\` https://github.github.com/gfm/#example-658