### PR TITLE
[doc] Improve contributing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ matrix:
     script:
     - cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
 script:
+  - cargo test --workspace --verbose
   - cargo test --workspace --all-features --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ matrix:
     name: Clippy
     before_script: rustup component add clippy
     script:
-    - cargo clippy --workspace --all-features -- -D warnings
+    - cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
 script:
   - cargo test --workspace --all-features --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ For the static analysis, we use [`clippy`].
 
 ```sh
 # To format the source code in the entire repository
-cargo clippy --workspace
+cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions
 ```
 
 [`clippy`]: https://github.com/rust-lang/rust-clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ When making a feature request, please make it clear what problem you intend to
 solve with the feature, any ideas for how `transit_model` could support solving
 that problem, any possible alternatives, and any disadvantages.
 
+### Internal work management tool
+
+At Kisio Digital (ex. CanalTP) we track tasks and bugs using a private tool.
+This tool is private but we sometimes refer to it when submitting
+PRs (those `Ref. ND-123`), to help later work.
+Feel free to ask for more details if the description is too narrow,
+we should be able to provide information from tracking tool if there is more.
+
 ## Checking quality
 
 We encourage you to check that the formatting, static analysis and test suite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Note: this may be very (very) slow on huge files.
 
 ```sh
 # Run all the tests of `transit_model` in the entire repository,
-# without fixtures, then activating all features, including `xmllint`
+# activating all features (including `xmllint`), then without features
 # to make sure that both works
 cargo test --workspace --all-features && cargo test --workspace
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,19 +67,19 @@ git submodule update --init --recursive
 apt install libxml2-utils
 ```
 
+#### Check outputs manually
+
+To validate the output NeTEx obtained it is possible to use xmllint:
+```sh
+xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd your_file.xml
+```
+
 #### Launch all tests
 
 ```sh
 # Run all the tests of `transit_model` in the entire repository,
 # activating all features, including `xmllint`
 cargo test --workspace --all-features
-```
-
-#### Hand-check outputs
-
-To validate the output NeTEx obtained it is possible to use xmllint:
-```sh
-xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd your_file.xml
 ```
 
 ## Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ cargo fmt --all
 For the static analysis, we use [`clippy`].
 
 ```sh
-# To format the source code in the entire repository
-cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions
+# Check lints on the source code in the entire repository
+cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
 ```
 
 [`clippy`]: https://github.com/rust-lang/rust-clippy
@@ -77,10 +77,11 @@ apt install libxml2-utils
 
 #### Check outputs manually
 
-To validate the output NeTEx obtained it is possible to use xmllint:
+To validate the NeTEx output it is possible to use xmllint:
 ```sh
 xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd your_file.xml
 ```
+Note: this may be very (very) slow on huge files.
 
 #### Launch all tests
 
@@ -88,17 +89,16 @@ xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd
 # Run all the tests of `transit_model` in the entire repository,
 # without fixtures, then activating all features, including `xmllint`
 # to make sure that both works
-cargo test --workspace ; cargo test --workspace --all-features
+cargo test --workspace --all-features && cargo test --workspace
 ```
 
 ## Environments and tools
 
 At Kisio Digital, we mostly maintain, test and operate on the following
-environments and tools.
+environments and tools:
 
-Our main target for OS is [Debian].
-
-Our main target for [PROJ] is the version `6.3.0`.
+* Our main target for OS is [Debian].
+* Our main target for [PROJ] is the version `6.3.0`.
 
 However, we are open to contributions to help support more of them.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,9 @@ xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd
 
 ```sh
 # Run all the tests of `transit_model` in the entire repository,
-# activating all features, including `xmllint`
-cargo test --workspace --all-features
+# without fixtures, then activating all features, including `xmllint`
+# to make sure that both works
+cargo test --workspace ; cargo test --workspace --all-features
 ```
 
 ## Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,20 @@ xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd
 cargo test --workspace ; cargo test --workspace --all-features
 ```
 
+## Environments and tools
+
+At Kisio Digital, we mostly maintain, test and operate on the following
+environments and tools.
+
+Our main target for OS is [Debian].
+
+Our main target for [PROJ] is the version `6.3.0`.
+
+However, we are open to contributions to help support more of them.
+
+[Debian]: https://www.debian.org
+[PROJ]: https://proj.org
+
 ## Conduct
 
 We follow the [Rust Code of Conduct].

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,7 @@ Tests also depend on NeTEx specification that are imported as a git submodule.
 Therefore, these tests are run only if feature `xmllint` is activated.\
 
 To install xmllint and submodules:
+
 ```sh
 git submodule update --init --recursive
 apt install libxml2-utils
@@ -78,9 +79,11 @@ apt install libxml2-utils
 #### Check outputs manually
 
 To validate the NeTEx output it is possible to use xmllint:
+
 ```sh
 xmllint --noout --nonet --huge --schema /path/to/NeTEx/xsd/NeTEx_publication.xsd your_file.xml
 ```
+
 Note: this may be very (very) slow on huge files.
 
 #### Launch all tests
@@ -98,7 +101,8 @@ At Kisio Digital, we mostly maintain, test and operate on the following
 environments and tools:
 
 * Our main target for OS is [Debian].
-* Our main target for [PROJ] is the version `6.3.0`.
+* Our main target for [PROJ] is the version described in the
+  [main README](README.md#PROJ-for-binaries).
 
 However, we are open to contributions to help support more of them.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ may help, too.
 
 ### Using [PROJ] and transit_model as a developer
 
-[`proj` crate] is a binding to the C library (version `6.3.0`).
+[`proj` crate] is a binding to the C library.
 
 [PROJ] is configured as a `feature` of the `transit_model` crate.\
 So to use it for coding, the `proj` feature must be activated

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Please check documentation attached to each crate:
 
 `transit_model` is developed in [Rust].
 
-If you want to contribute or install binaries, you need to install a [Rust] environment: see https://rustup.rs
+If you want to contribute or install binaries, you need to install a [Rust] environment: see [rustup.rs]
 
-[Rust]: https://www.rust-lang.org/
+[Rust]: https://www.rust-lang.org
+[rustup.rs]: https://rustup.rs
 
 ## [PROJ] dependency
 
@@ -71,6 +72,7 @@ Then specific code should be conditionally enabled with
 
 `transit_model` is supporting most of [NTFS] format.\
 From the standard, some of the functionalities are not fully supported:
+
 * No support for Line Groups (files `line_groups.txt` and `line_group_links.txt`).
 * The field `trip_short_name_at_stop` in `stop_times.txt` introduced in version
   `v0.10.0` (see [NTFS changelog in French]) is not supported.

--- a/gtfs2netexfr/README.md
+++ b/gtfs2netexfr/README.md
@@ -35,7 +35,7 @@ gtfs2netexfr --input /path/to/gtfs/folder/ --output /path/to/netexfr/ --particip
 
 Get more information about the available options with `gtfs2netexfr --help`.
 
-Finally, it's possible to [hand-check the output](../CONTRIBUTING.md#hand-check-outputs).
+Finally, it's possible to [check the output manually](../CONTRIBUTING.md#check-outputs-manually).
 
 ## Specifications
 


### PR DESCRIPTION
* Consistency on how `clippy` and `test` are checked
* Word on our environments and tools

This work is debatable.
A future PR should attempt to use cargo (and maybe makefile) to minimize/centralize commands to type.

Ref. ND-930