### PR TITLE
[tech] [doc] Centralize fmt, clippy & test in makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,8 @@ jobs:
           toolchain: stable
           profile: minimal
           components: rustfmt
-    - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+    - name: Check formatting
+      run: make format
 
   clippy:
     name: Analyzing code with Clippy
@@ -39,11 +36,8 @@ jobs:
           toolchain: stable
           profile: minimal
           components: clippy
-    - name: Run cargo clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
+    - name: Linting
+      run: make lint
 
   tests:
     name: Tests
@@ -74,13 +68,5 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
           override: true
-    - name: Run tests without features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --verbose
-    - name: Run tests with all features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --workspace --verbose --all-features
+    - name: Run tests with and without features
+      run: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,12 @@ addons:
 matrix:
   include:
   - rust: stable
-    name: Linting
+    name: Formatting
     before_script: rustup component add rustfmt
-    script: cargo fmt --all -- --check
+    script: make format
   - rust: stable
-    name: Clippy
+    name: Linting
     before_script: rustup component add clippy
-    script:
-    - cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
+    script: make lint
 script:
-  - cargo test --workspace --verbose
-  - cargo test --workspace --all-features --verbose
+  - make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ We use the standard Rust formatting tool, [`rustfmt`].
 
 ```sh
 # To format the source code in the entire repository
-cargo fmt --all
+make format
 ```
 
 [`rustfmt`]: https://github.com/rust-lang/rustfmt
@@ -49,7 +49,7 @@ For the static analysis, we use [`clippy`].
 
 ```sh
 # Check lints on the source code in the entire repository
-cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
+make lint
 ```
 
 [`clippy`]: https://github.com/rust-lang/rust-clippy
@@ -91,8 +91,8 @@ Note: this may be very (very) slow on huge files.
 ```sh
 # Run all the tests of `transit_model` in the entire repository,
 # activating all features (including `xmllint`), then without features
-# to make sure that both works
-cargo test --workspace --all-features && cargo test --workspace
+# to make sure that both work
+make test
 ```
 
 ## Environments and tools

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,24 @@ install_proj: ## Install PROJ and clang (requirements to use proj crate)
 	sudo make install
 	popd
 	rm -rf proj-$(PROJ_VERSION) proj-$(PROJ_VERSION).tar.gz
+
+fmt: format ## Check formatting of the code (alias for 'format')
+format: ## Check formatting of the code
+	cargo fmt --all -- --check
+
+clippy: lint ## Check quality of the code (alias for 'lint')
+lint: ## Check quality of the code
+	cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
+
+test: ## Launch all tests
+	# Run all the tests of `transit_model` in the entire repository,
+	# activating all features (including `xmllint`), then without features
+	# to make sure that both work
+	cargo test --workspace --all-features
+	cargo test --workspace
+
+help: ## Print this help message
+	@grep -E '^[a-zA-Z_-]+:.*## .*$$' $(CURDIR)/$(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: install_proj fmt format clippy lint test help
+.DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 PROJ_VERSION = 6.3.0
-
-install_proj:
+install_proj: ## Install PROJ and clang (requirements to use proj crate)
 	sudo apt update
-	sudo apt install -y wget build-essential pkg-config sqlite3 libsqlite3-dev clang
-	wget https://github.com/OSGeo/proj.4/releases/download/$(PROJ_VERSION)/proj-$(PROJ_VERSION).tar.gz && tar -xzvf proj-$(PROJ_VERSION).tar.gz
-	cd proj-$(PROJ_VERSION) && ./configure --prefix=/usr && make && sudo make install
+	sudo apt install -y clang
+
+	# Needed only for proj install
+	sudo apt install -y wget build-essential pkg-config sqlite3 libsqlite3-dev
+
+	# remove PROJ system version from packages
+	sudo apt remove libproj-dev
+
+	wget https://github.com/OSGeo/proj.4/releases/download/$(PROJ_VERSION)/proj-$(PROJ_VERSION).tar.gz
+	tar -xzvf proj-$(PROJ_VERSION).tar.gz
+	pushd proj-$(PROJ_VERSION)
+	./configure --prefix=/usr && make
+	sudo make install
+	popd
 	rm -rf proj-$(PROJ_VERSION) proj-$(PROJ_VERSION).tar.gz

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,14 @@ lint: ## Check quality of the code
 	cargo clippy --workspace --all-features --all-targets -- --warn clippy::cargo --allow clippy::multiple_crate_versions --deny warnings
 
 test: ## Launch all tests
-	# Run all the tests of `transit_model` in the entire repository,
-	# activating all features (including `xmllint`), then without features
-	# to make sure that both work
-	cargo test --workspace --all-features
-	cargo test --workspace
+	# Run all the tests of `transit_model` in the entire repository.
+
+	# First activating all features (including `xmllint`)
+	cargo test --workspace --all-features --all-targets  # `--all-targets` but no doctests
+	cargo test --workspace --all-features --doc          # doctests only
+	# Then without features
+	cargo test --workspace --all-targets                 # `--all-targets` but no doctests
+	cargo test --workspace --doc                         # doctests only
 
 help: ## Print this help message
 	@grep -E '^[a-zA-Z_-]+:.*## .*$$' $(CURDIR)/$(firstword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -13,19 +13,23 @@ This is done by implementing the [NTFS] model (used in [navitia]).
 This repository regroups crates that offer enabler-libraries and binaries to
 convert and enrich transit data.
 
+Additionally, `transit_model` is itself a library providing various
+functionalities. Please refer to the code and documentation to discover them.
+
 Please check documentation attached to each crate:
 
-* [**gtfs2netexfr**](gtfs2netexfr/README.md) converts [GTFS] data format into
-  [NeTEx]-France data format.
-* [**gtfs2ntfs**](gtfs2ntfs/README.md) converts [GTFS] data format into [NTFS]
-  data format.
-* [**ntfs2gtfs**](ntfs2gtfs/README.md) converts [NTFS] data format into [GTFS]
-  data format.
-* [**ntfs2netexfr**](ntfs2netexfr/README.md) converts [NTFS] data format into
-  [NeTEx]-France data format.
-* [**ntfs2ntfs**](ntfs2ntfs/README.md) checks and cleans a [NTFS] dataset.
-* [**restrict-validity-period**](restrict-validity-period/README.md) restricts
-  the validity period of a [NTFS] dataset and purges out-of-date data.
+* binary [**gtfs2netexfr**](gtfs2netexfr/README.md) converts [GTFS] data format
+  into [NeTEx]-France data format.
+* binary [**gtfs2ntfs**](gtfs2ntfs/README.md) converts [GTFS] data format into
+  [NTFS] data format.
+* binary [**ntfs2gtfs**](ntfs2gtfs/README.md) converts [NTFS] data format into
+  [GTFS] data format.
+* binary [**ntfs2netexfr**](ntfs2netexfr/README.md) converts [NTFS] data format
+  into [NeTEx]-France data format.
+* binary [**ntfs2ntfs**](ntfs2ntfs/README.md) checks and cleans a [NTFS]
+  dataset.
+* binary [**restrict-validity-period**](restrict-validity-period/README.md)
+  restricts the validity period of a [NTFS] dataset and purges out-of-date data.
 
 ## Setup Rust environment
 


### PR DESCRIPTION
Centralize in makefile and expose in doc and CI

Also:
* rm system package for install_proj (+ comments and cosmetic refactor)
* minor doc update after update on TT (https://github.com/CanalTP/tartare-tools/pull/103#discussion_r451521210)

TODO:
- [x] bump version > No need, "major" bump in another PR

Ref. ND-947