### PR TITLE
[feature] Auto-generate route.destination_id if missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.21.0"
+version = "0.22.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.21", path = "../", features = ["proj"] }
+transit_model = { version = "0.22", path = "../", features = ["proj"] }

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.21", path = "../" }
+transit_model = { version = "0.22", path = "../" }

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.21", path = "../" }
+transit_model = { version = "0.22", path = "../" }

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.21", path = "../", features = ["proj"] }
+transit_model = { version = "0.22", path = "../", features = ["proj"] }

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.21", path = "../" }
+transit_model = { version = "0.22", path = "../" }

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -21,4 +21,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.21", path = "../" }
+transit_model = { version = "0.22", path = "../" }

--- a/tests/fixtures/restrict-validity-period/output/routes.txt
+++ b/tests/fixtures/restrict-validity-period/output/routes.txt
@@ -1,8 +1,8 @@
 route_id,route_name,direction_type,line_id,geometry_id,destination_id
-M1F,Nation - Charles de Gaulle,forward,M1,geo:2:kept,
-M1B,Charles de Gaulle - Nation,forward,M1,,
-B42F,Gare de Lyon - Montparnasse,forward,B42,,
-B42B,Montparnasse - Gare de Lyon,forward,B42,,
-M1B_R,Charles de Gaulle - Nation retour,forward,M1,,
-B42F_R,Gare de Lyon - Montparnasse retour,forward,B42,,
-B42B_R,Montparnasse - Gare de Lyon retour,forward,B42,,
+M1F,Nation - Charles de Gaulle,forward,M1,geo:2:kept,GDL
+M1B,Charles de Gaulle - Nation,forward,M1,,NAT
+B42F,Gare de Lyon - Montparnasse,forward,B42,,MTP
+B42B,Montparnasse - Gare de Lyon,forward,B42,,GDL
+M1B_R,Charles de Gaulle - Nation retour,forward,M1,,GDL
+B42F_R,Gare de Lyon - Montparnasse retour,forward,B42,,GDL
+B42B_R,Montparnasse - Gare de Lyon retour,forward,B42,,GDL


### PR DESCRIPTION
Auto-generate `route.destination_id` always (it was auto-generated only when `route.name` was empty).

ref: ND-916