### PR TITLE
[feature] Improve route_name generation in GTFS parsing

### DIFF
--- a/documentation/gtfs_to_ntfs_specs.md
+++ b/documentation/gtfs_to_ntfs_specs.md
@@ -158,15 +158,20 @@ _Warning :_ If the GTFS route has no trips, the Navitia Route should NOT be crea
 | NTFS file    | NTFS field     | Constraint | GTFS file  | GTFS field      | Note                                                                                                                                                        |
 | ------------ | -------------- | ---------- | ---------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | routes.txt   | route_id       | ID         | routes.txt | route_id        | append a `_R` suffix for the Route grouping trips with `direction_id` = 1 (no suffix for `0` or undefined `direction_id`)                                   |
-| routes.txt   | route_name     | Required   | routes.txt | route_long_name | if `route_long_name` is empty, use `route_short_name`                                                                                                       |
-| routes.txt   | direction_type | Optional   |            |                 | (1)                                                                                                                                                         |
+| routes.txt   | route_name     | Required   | routes.txt | route_long_name | (1)                                                                                                                                                         |
+| routes.txt   | direction_type | Optional   |            |                 | (2)                                                                                                                                                         |
 | routes.txt   | line_id        | Required   |            |                 | corresponding `line.id` (see Line construction above)                                                                                                       |
 | routes.txt   | destination_id | Optional   |            |                 | This field contains a stop_area.id of the most frequent destination of the contained trips (ie. the parent_station of the most frequent last stop of trips) |
-| comments.txt | comment_value  | Optional   | routes.txt | route_desc      | See (2) for additional properties                                                                                                                           |
+| comments.txt | comment_value  | Optional   | routes.txt | route_desc      | See (3) for additional properties                                                                                                                           |
 
-(1) the field `direction_type` contains `backward` when grouping GTFS Trips with `direction_id` = 1, `forward` otherwise
+(1) if only one route is created (only one direction in included trips), use
+`route_long_name` or, if empty, use `route_short_name`. In case of multiple
+routes created (multiple directions in included trips), see [common NTFS rules]
+for generating the `route_name`.
 
-(2) The `comment` object is a complex type with additional properties :
+(2) the field `direction_type` contains `backward` when grouping GTFS Trips with `direction_id` = 1, `forward` otherwise
+
+(3) The `comment` object is a complex type with additional properties :
 * `comment_id` : specify an identifier with the pattern **\<prefix>:route:<route_id of GTFS>**
 * `comment_type` : specify the fixed value "Information"
 

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -1043,10 +1043,23 @@ fn make_routes(gtfs_trips: &[Trip], map_line_routes: &MapLineRoutes<'_>) -> Vec<
                 route_directions.insert(t.direction);
             }
 
+            let has_one_direction = route_directions.len() <= 1;
             for d in route_directions {
                 routes.push(objects::Route {
                     id: r.get_id_by_direction(d),
-                    name: r.long_name.clone(),
+                    // When only one direction, keep the route name. When
+                    // multiple directions are possible, leave the `route_name`
+                    // empty, it'll be auto-generated later in
+                    // `Collections::enhance_route_names()`.
+                    name: if has_one_direction {
+                        if !r.long_name.is_empty() {
+                            r.long_name.clone()
+                        } else {
+                            r.short_name.clone()
+                        }
+                    } else {
+                        String::new()
+                    },
                     direction_type: Some(get_direction_name(d)),
                     codes: KeysValues::default(),
                     object_properties: KeysValues::default(),

--- a/tests/fixtures/gtfs2ntfs/minimal/output/routes.txt
+++ b/tests/fixtures/gtfs2ntfs/minimal/output/routes.txt
@@ -1,3 +1,3 @@
 route_id,route_name,direction_type,line_id,geometry_id,destination_id
-route:2,plop - plop,forward,route:2,,stoparea:1
-route:3,plop - plop,forward,route:3,,stoparea:1
+route:2,ma route 1,forward,route:2,,stoparea:1
+route:3,ma route 2,forward,route:3,,stoparea:1

--- a/tests/fixtures/gtfs2ntfs/no_traffic/output/routes.txt
+++ b/tests/fixtures/gtfs2ntfs/no_traffic/output/routes.txt
@@ -1,2 +1,2 @@
 route_id,route_name,direction_type,line_id,geometry_id,destination_id
-route:2,plop - plop,forward,route:2,,stoparea:1
+route:2,ma route 1,forward,route:2,,stoparea:1

--- a/tests/fixtures/netex_france/input_ntfs/routes.txt
+++ b/tests/fixtures/netex_france/input_ntfs/routes.txt
@@ -1,7 +1,7 @@
 route_id,route_name,line_id,direction_type
-M1,Metro 1,M1,inbound
-M1_R,Metro 1,M1,outbound
-B42,Bus 42,B42,forward
-B42_R,Bus 42,B42,backward
+M1,Nation - Charles de Gaulle,M1,inbound
+M1_R,Charles de Gaulle - Nation,M1,outbound
+B42,Gare de Lyon - Montparnasse,B42,forward
+B42_R,Montparnasse - Gare de Lyon,B42,backward
 RERA,RER A,RERA,inbound
 RERA_Bus_R,RER A,RERA,outbound

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
@@ -6,7 +6,7 @@
 		<GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE:" version="any">
 			<members>
 				<Route id="FR:Route:B42:" version="any">
-					<Name>Bus 42</Name>
+					<Name>Gare de Lyon - Montparnasse</Name>
 					<Distance>0</Distance>
 					<LineRef ref="FR:Line:B42:">
 					</LineRef>
@@ -23,7 +23,7 @@
 					</pointsInSequence>
 				</Route>
 				<Route id="FR:Route:B42_R:" version="any">
-					<Name>Bus 42</Name>
+					<Name>Montparnasse - Gare de Lyon</Name>
 					<Distance>0</Distance>
 					<LineRef ref="FR:Line:B42:">
 					</LineRef>

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
@@ -6,7 +6,7 @@
 		<GeneralFrame id="FR:GeneralFrame:NETEX_HORAIRE:" version="any">
 			<members>
 				<Route id="FR:Route:M1:" version="any">
-					<Name>Metro 1</Name>
+					<Name>Nation - Charles de Gaulle</Name>
 					<Distance>0</Distance>
 					<LineRef ref="FR:Line:M1:">
 					</LineRef>
@@ -31,7 +31,7 @@
 					</pointsInSequence>
 				</Route>
 				<Route id="FR:Route:M1_R:" version="any">
-					<Name>Metro 1</Name>
+					<Name>Charles de Gaulle - Nation</Name>
 					<Distance>0</Distance>
 					<LineRef ref="FR:Line:M1:">
 					</LineRef>


### PR DESCRIPTION
When creating a Route, we want to apply generic `route_name` generation unless all trips in that route are in the same direction, in this case, we keep the route's name.

Bonus: The specification proposes to use `route_short_name` if `route_long_name` is empty but our previous implementation was only using `route_long_name`. This PR fixes it.

ref: ND-681