### PR TITLE
[feature] AddPrefix can prefix referential or scheduled objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.23.0"
+version = "0.24.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.23", path = "../", features = ["proj"] }
+transit_model = { version = "0.24", path = "../", features = ["proj"] }

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.23", path = "../" }
+transit_model = { version = "0.24", path = "../" }

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.23", path = "../" }
+transit_model = { version = "0.24", path = "../" }

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.23", path = "../", features = ["proj"] }
+transit_model = { version = "0.24", path = "../", features = ["proj"] }

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -22,4 +22,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.23", path = "../" }
+transit_model = { version = "0.24", path = "../" }

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -21,4 +21,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.23", path = "../" }
+transit_model = { version = "0.24", path = "../" }

--- a/src/add_prefix.rs
+++ b/src/add_prefix.rs
@@ -90,7 +90,8 @@ impl PrefixConfiguration {
             prefix = prefix + data_prefix + &self.sep;
         }
         if let Some(dataset_id) = self.dataset_id.as_ref() {
-            prefix = prefix + &dataset_id[0..PREFIX_DATASET_LENGTH] + &self.sep;
+            let truncate_index = usize::min(dataset_id.len(), PREFIX_DATASET_LENGTH);
+            prefix = prefix + &dataset_id[0..truncate_index] + &self.sep;
         }
         prefix + id
     }

--- a/src/add_prefix.rs
+++ b/src/add_prefix.rs
@@ -158,7 +158,7 @@ fn add_prefix_on_vehicle_journey_ids(
         .iter()
         .map(|((trip_id, sequence), value)| {
             (
-                (prefix_conf.referential_prefix(trip_id.as_str()), *sequence),
+                (prefix_conf.schedule_prefix(trip_id.as_str()), *sequence),
                 value.to_string(),
             )
         })
@@ -173,8 +173,8 @@ fn add_prefix_on_vehicle_journey_ids_and_values(
         .iter()
         .map(|((trip_id, sequence), value)| {
             (
-                (prefix_conf.referential_prefix(trip_id.as_str()), *sequence),
-                prefix_conf.referential_prefix(value.as_str()),
+                (prefix_conf.schedule_prefix(trip_id.as_str()), *sequence),
+                prefix_conf.schedule_prefix(value.as_str()),
             )
         })
         .collect()

--- a/src/add_prefix.rs
+++ b/src/add_prefix.rs
@@ -18,25 +18,122 @@ use crate::model::Collections;
 use std::collections::HashMap;
 use typed_index_collection::{Collection, CollectionWithId, Id};
 
+const PREFIX_DATASET_LENGTH: usize = 6;
+
+/// Metadata for building the prefix.
+#[derive(Debug)]
+pub struct PrefixConfiguration {
+    /// Separator used in the prefix, usually ':'.
+    sep: String,
+    /// General data prefix (historically a trigram) used for discriminating
+    /// referential objects (like Network).  Usually useful to avoid collisions
+    /// when merging dataset from different contributors.
+    data_prefix: Option<String>,
+    /// Unique identifier of the dataset, used for discriminating scheduled
+    /// objects (like Calendar).  Usually useful to avoid collisions when
+    /// merging dataset from the same contributor.
+    dataset_id: Option<String>,
+}
+
+impl Default for PrefixConfiguration {
+    fn default() -> Self {
+        PrefixConfiguration {
+            sep: String::from(":"),
+            data_prefix: None,
+            dataset_id: None,
+        }
+    }
+}
+
+impl PrefixConfiguration {
+    /// Set the prefix separator for PrefixConfiguration.
+    pub fn set_sep<S>(&mut self, sep: S)
+    where
+        S: ToString,
+    {
+        self.sep = sep.to_string();
+    }
+
+    /// Set the data_prefix in the PrefixConfiguration.
+    pub fn set_data_prefix<S>(&mut self, data_prefix: S)
+    where
+        S: ToString,
+    {
+        self.data_prefix = Some(data_prefix.to_string());
+    }
+
+    /// Set the dataset_id in the PrefixConfiguration.
+    pub fn set_dataset_id<S>(&mut self, dataset_id: S)
+    where
+        S: ToString,
+    {
+        self.dataset_id = Some(dataset_id.to_string());
+    }
+
+    /// Add prefix for referential-type object.
+    ///
+    /// Example of objects from the referential are Line or StopPoint.
+    pub fn referential_prefix(&self, id: &str) -> String {
+        let mut prefix = String::new();
+        if let Some(data_prefix) = self.data_prefix.as_ref() {
+            prefix = prefix + data_prefix + &self.sep;
+        }
+        prefix + id
+    }
+
+    /// Add prefix for schedule-type object.
+    ///
+    /// Example of objects from the schedule are VehicleJourney or StopTime.
+    pub fn schedule_prefix(&self, id: &str) -> String {
+        let mut prefix = String::new();
+        if let Some(data_prefix) = self.data_prefix.as_ref() {
+            prefix = prefix + data_prefix + &self.sep;
+        }
+        if let Some(dataset_id) = self.dataset_id.as_ref() {
+            prefix = prefix + &dataset_id[0..PREFIX_DATASET_LENGTH] + &self.sep;
+        }
+        prefix + id
+    }
+}
+
 /// Trait for object that can be prefixed
 pub trait AddPrefix {
     /// Add the prefix to all elements of the object that needs to be prefixed.
-    fn add_prefix(&mut self, prefix: &str);
+    #[deprecated(since = "0.24.0", note = "please use `AddPrefix::prefix()` instead")]
+    fn add_prefix(&mut self, prefix: &str) {
+        let prefix_conf = PrefixConfiguration {
+            sep: String::new(),
+            data_prefix: Some(prefix.to_string()),
+            dataset_id: None,
+        };
+        self.prefix(&prefix_conf);
+    }
+
     /// Add the prefix to all elements of the object that needs to be prefixed.
     /// A separator will be placed between the prefix and the identifier.
+    #[deprecated(since = "0.24.0", note = "please use `AddPrefix::prefix()` instead")]
     fn add_prefix_with_sep(&mut self, prefix: &str, sep: &str) {
-        let prefix = format!("{}{}", prefix, sep);
-        self.add_prefix(&prefix);
+        let prefix_conf = PrefixConfiguration {
+            sep: String::from(sep),
+            data_prefix: Some(prefix.to_string()),
+            dataset_id: None,
+        };
+        self.prefix(&prefix_conf);
     }
+
+    /// Add the prefix to all elements of the object that needs to be prefixed.
+    /// PrefixConfiguration contains all the needed metadata to create the
+    /// complete prefix.
+    fn prefix(&mut self, prefix_conf: &PrefixConfiguration);
 }
 
 impl<T> AddPrefix for Collection<T>
 where
     T: AddPrefix,
 {
-    fn add_prefix(&mut self, prefix: &str) {
+    fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
         for obj in &mut self.values_mut() {
-            obj.add_prefix(prefix);
+            obj.prefix(prefix_conf);
         }
     }
 }
@@ -45,23 +142,23 @@ impl<T> AddPrefix for CollectionWithId<T>
 where
     T: Id<T> + AddPrefix,
 {
-    fn add_prefix(&mut self, prefix: &str) {
+    fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
         let indexes: Vec<_> = self.iter().map(|(idx, _)| idx).collect();
         for index in indexes {
-            self.index_mut(index).add_prefix(prefix);
+            self.index_mut(index).prefix(prefix_conf);
         }
     }
 }
 
 fn add_prefix_on_vehicle_journey_ids(
     vehicle_journey_ids: &HashMap<(String, u32), String>,
-    prefix: &str,
+    prefix_conf: &PrefixConfiguration,
 ) -> HashMap<(String, u32), String> {
     vehicle_journey_ids
         .iter()
         .map(|((trip_id, sequence), value)| {
             (
-                (format!("{}{}", prefix, trip_id), *sequence),
+                (prefix_conf.referential_prefix(trip_id.as_str()), *sequence),
                 value.to_string(),
             )
         })
@@ -70,59 +167,59 @@ fn add_prefix_on_vehicle_journey_ids(
 
 fn add_prefix_on_vehicle_journey_ids_and_values(
     vehicle_journey_ids: &HashMap<(String, u32), String>,
-    prefix: &str,
+    prefix_conf: &PrefixConfiguration,
 ) -> HashMap<(String, u32), String> {
     vehicle_journey_ids
         .iter()
         .map(|((trip_id, sequence), value)| {
             (
-                (format!("{}{}", prefix, trip_id), *sequence),
-                format!("{}{}", prefix, value.to_string()),
+                (prefix_conf.referential_prefix(trip_id.as_str()), *sequence),
+                prefix_conf.referential_prefix(value.as_str()),
             )
         })
         .collect()
 }
 
 impl AddPrefix for Collections {
-    fn add_prefix(&mut self, prefix: &str) {
-        self.contributors.add_prefix(&prefix);
-        self.datasets.add_prefix(&prefix);
-        self.networks.add_prefix(&prefix);
-        self.lines.add_prefix(&prefix);
-        self.routes.add_prefix(&prefix);
-        self.vehicle_journeys.add_prefix(&prefix);
-        self.frequencies.add_prefix(&prefix);
-        self.stop_areas.add_prefix(&prefix);
-        self.stop_points.add_prefix(&prefix);
-        self.stop_locations.add_prefix(&prefix);
-        self.calendars.add_prefix(&prefix);
-        self.companies.add_prefix(&prefix);
-        self.comments.add_prefix(&prefix);
-        self.equipments.add_prefix(&prefix);
-        self.transfers.add_prefix(&prefix);
-        self.trip_properties.add_prefix(&prefix);
-        self.geometries.add_prefix(&prefix);
-        self.admin_stations.add_prefix(&prefix);
-        self.prices_v1.add_prefix(&prefix);
-        self.od_fares_v1.add_prefix(&prefix);
-        self.fares_v1.add_prefix(&prefix);
-        self.tickets.add_prefix(&prefix);
-        self.ticket_prices.add_prefix(&prefix);
-        self.ticket_uses.add_prefix(&prefix);
-        self.ticket_use_perimeters.add_prefix(&prefix);
-        self.ticket_use_restrictions.add_prefix(&prefix);
-        self.pathways.add_prefix(&prefix);
-        self.levels.add_prefix(&prefix);
-        self.grid_calendars.add_prefix(&prefix);
-        self.grid_exception_dates.add_prefix(&prefix);
-        self.grid_periods.add_prefix(&prefix);
-        self.grid_rel_calendar_line.add_prefix(&prefix);
+    fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
+        self.contributors.prefix(prefix_conf);
+        self.datasets.prefix(prefix_conf);
+        self.networks.prefix(prefix_conf);
+        self.lines.prefix(prefix_conf);
+        self.routes.prefix(prefix_conf);
+        self.vehicle_journeys.prefix(prefix_conf);
+        self.frequencies.prefix(prefix_conf);
+        self.stop_areas.prefix(prefix_conf);
+        self.stop_points.prefix(prefix_conf);
+        self.stop_locations.prefix(prefix_conf);
+        self.calendars.prefix(prefix_conf);
+        self.companies.prefix(prefix_conf);
+        self.comments.prefix(prefix_conf);
+        self.equipments.prefix(prefix_conf);
+        self.transfers.prefix(prefix_conf);
+        self.trip_properties.prefix(prefix_conf);
+        self.geometries.prefix(prefix_conf);
+        self.admin_stations.prefix(prefix_conf);
+        self.prices_v1.prefix(prefix_conf);
+        self.od_fares_v1.prefix(prefix_conf);
+        self.fares_v1.prefix(prefix_conf);
+        self.tickets.prefix(prefix_conf);
+        self.ticket_prices.prefix(prefix_conf);
+        self.ticket_uses.prefix(prefix_conf);
+        self.ticket_use_perimeters.prefix(prefix_conf);
+        self.ticket_use_restrictions.prefix(prefix_conf);
+        self.pathways.prefix(prefix_conf);
+        self.levels.prefix(prefix_conf);
+        self.grid_calendars.prefix(prefix_conf);
+        self.grid_exception_dates.prefix(prefix_conf);
+        self.grid_periods.prefix(prefix_conf);
+        self.grid_rel_calendar_line.prefix(prefix_conf);
         self.stop_time_headsigns =
-            add_prefix_on_vehicle_journey_ids(&self.stop_time_headsigns, &prefix);
+            add_prefix_on_vehicle_journey_ids(&self.stop_time_headsigns, prefix_conf);
         self.stop_time_ids =
-            add_prefix_on_vehicle_journey_ids_and_values(&self.stop_time_ids, &prefix);
+            add_prefix_on_vehicle_journey_ids_and_values(&self.stop_time_ids, prefix_conf);
         self.stop_time_comments =
-            add_prefix_on_vehicle_journey_ids_and_values(&self.stop_time_comments, &prefix);
+            add_prefix_on_vehicle_journey_ids_and_values(&self.stop_time_comments, prefix_conf);
     }
 }
 
@@ -141,17 +238,19 @@ mod tests {
         }
     }
     impl AddPrefix for Obj {
-        fn add_prefix(&mut self, prefix: &str) {
-            self.0 = format!("{}:{}", prefix, self.0);
+        fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
+            self.0 = prefix_conf.schedule_prefix(self.0.as_str());
         }
     }
 
     #[test]
-    fn collection() {
+    fn collection_referential() {
         let obj1 = Obj(String::from("some_id"));
         let obj2 = Obj(String::from("other_id"));
         let mut collection = Collection::new(vec![obj1, obj2]);
-        collection.add_prefix("pre");
+        let mut prefix_conf = PrefixConfiguration::default();
+        prefix_conf.set_data_prefix("pre");
+        collection.prefix(&prefix_conf);
         let mut values = collection.values();
         let element = values.next().unwrap();
         assert_eq!(String::from("pre:some_id"), element.0);
@@ -160,11 +259,73 @@ mod tests {
     }
 
     #[test]
-    fn collection_with_id() {
+    fn collection_schedule() {
+        let obj1 = Obj(String::from("some_id"));
+        let obj2 = Obj(String::from("other_id"));
+        let mut collection = Collection::new(vec![obj1, obj2]);
+        let mut prefix_conf = PrefixConfiguration::default();
+        prefix_conf.set_data_prefix("pre");
+        prefix_conf.set_dataset_id("abcdefghijklmnopqrstuvwxyz");
+        collection.prefix(&prefix_conf);
+        let mut values = collection.values();
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:abcdef:some_id"), element.0);
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:abcdef:other_id"), element.0);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn collection_deprecated() {
+        let obj1 = Obj(String::from("some_id"));
+        let obj2 = Obj(String::from("other_id"));
+        let mut collection = Collection::new(vec![obj1, obj2]);
+        collection.add_prefix("pre:");
+        let mut values = collection.values();
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:some_id"), element.0);
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:other_id"), element.0);
+    }
+
+    #[test]
+    fn collection_with_id_referential() {
         let obj1 = Obj(String::from("some_id"));
         let obj2 = Obj(String::from("other_id"));
         let mut collection = CollectionWithId::new(vec![obj1, obj2]).unwrap();
-        collection.add_prefix("pre");
+        let mut prefix_conf = PrefixConfiguration::default();
+        prefix_conf.set_data_prefix("pre");
+        collection.prefix(&prefix_conf);
+        let mut values = collection.values();
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:some_id"), element.0);
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:other_id"), element.0);
+    }
+
+    #[test]
+    fn collection_with_id_schedule() {
+        let obj1 = Obj(String::from("some_id"));
+        let obj2 = Obj(String::from("other_id"));
+        let mut collection = CollectionWithId::new(vec![obj1, obj2]).unwrap();
+        let mut prefix_conf = PrefixConfiguration::default();
+        prefix_conf.set_data_prefix("pre");
+        prefix_conf.set_dataset_id("abcdefghijklmnopqrstuvwxyz");
+        collection.prefix(&prefix_conf);
+        let mut values = collection.values();
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:abcdef:some_id"), element.0);
+        let element = values.next().unwrap();
+        assert_eq!(String::from("pre:abcdef:other_id"), element.0);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn collection_with_id_deprecated() {
+        let obj1 = Obj(String::from("some_id"));
+        let obj2 = Obj(String::from("other_id"));
+        let mut collection = CollectionWithId::new(vec![obj1, obj2]).unwrap();
+        collection.add_prefix("pre:");
         let mut values = collection.values();
         let element = values.next().unwrap();
         assert_eq!(String::from("pre:some_id"), element.0);

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     objects::{Availability, StopPoint, StopType, Time},
     read_utils,
     utils::*,
-    validity_period, AddPrefix, Result,
+    validity_period, AddPrefix, PrefixConfiguration, Result,
 };
 use derivative::Derivative;
 use log::info;
@@ -312,7 +312,9 @@ where
 
     //add prefixes
     if let Some(prefix) = configuration.prefix {
-        collections.add_prefix_with_sep(prefix.as_str(), ":");
+        let mut prefix_conf = PrefixConfiguration::default();
+        prefix_conf.set_data_prefix(prefix);
+        collections.prefix(&prefix_conf);
     }
 
     collections.calendar_deduplication();

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -1359,7 +1359,7 @@ mod tests {
         objects::{Calendar, Comment, CommentType, Equipment, Geometry, Rgb, StopTime, Transfer},
         read_utils::{self, read_opt_collection, PathFileHandler},
         test_utils::*,
-        AddPrefix,
+        AddPrefix, PrefixConfiguration,
     };
     use geo_types::line_string;
     use pretty_assertions::assert_eq;
@@ -2025,7 +2025,9 @@ mod tests {
             super::manage_shapes(&mut collections, &mut handler).unwrap();
             calendars::manage_calendars(&mut handler, &mut collections).unwrap();
 
-            collections.add_prefix_with_sep("my_prefix", ":");
+            let mut prefix_conf = PrefixConfiguration::default();
+            prefix_conf.set_data_prefix("my_prefix");
+            collections.prefix(&prefix_conf);
 
             assert_eq!(
                 vec!["my_prefix:285", "my_prefix:584"],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 #[macro_use]
 mod utils;
 mod add_prefix;
-pub use add_prefix::AddPrefix;
+pub use add_prefix::{AddPrefix, PrefixConfiguration};
 pub mod calendars;
 #[macro_use]
 pub mod objects;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -108,7 +108,7 @@ impl AddPrefix for CommentLinksT {
         let updated_ids = std::mem::replace(self, BTreeSet::new());
         *self = updated_ids
             .into_iter()
-            .map(|comment_id| prefix_conf.referential_prefix(comment_id.as_str()))
+            .map(|comment_id| prefix_conf.schedule_prefix(comment_id.as_str()))
             .collect();
     }
 }
@@ -520,6 +520,10 @@ impl AddPrefix for Line {
             .backward_direction
             .take()
             .map(|id| prefix_conf.referential_prefix(id.as_str()));
+        self.geometry_id = self
+            .geometry_id
+            .take()
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.comment_links.prefix(prefix_conf);
     }
 }
@@ -566,7 +570,7 @@ impl AddPrefix for Route {
         self.geometry_id = self
             .geometry_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.destination_id = self
             .destination_id
             .take()
@@ -642,19 +646,19 @@ impl_id!(VehicleJourney, Calendar, service_id);
 
 impl AddPrefix for VehicleJourney {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.id = prefix_conf.referential_prefix(self.id.as_str());
+        self.id = prefix_conf.schedule_prefix(self.id.as_str());
         self.route_id = prefix_conf.referential_prefix(self.route_id.as_str());
         self.dataset_id = prefix_conf.referential_prefix(self.dataset_id.as_str());
         self.company_id = prefix_conf.referential_prefix(self.company_id.as_str());
-        self.service_id = prefix_conf.referential_prefix(self.service_id.as_str());
+        self.service_id = prefix_conf.schedule_prefix(self.service_id.as_str());
         self.trip_property_id = self
             .trip_property_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.geometry_id = self
             .geometry_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.comment_links.prefix(prefix_conf);
     }
 }
@@ -687,7 +691,7 @@ pub struct Frequency {
 
 impl AddPrefix for Frequency {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.vehicle_journey_id = prefix_conf.referential_prefix(self.vehicle_journey_id.as_str());
+        self.vehicle_journey_id = prefix_conf.schedule_prefix(self.vehicle_journey_id.as_str());
     }
 }
 
@@ -1048,7 +1052,7 @@ impl AddPrefix for StopArea {
         self.geometry_id = self
             .geometry_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.level_id = self
             .level_id
             .take()
@@ -1115,7 +1119,7 @@ impl AddPrefix for StopPoint {
         self.geometry_id = self
             .geometry_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.level_id = self
             .level_id
             .take()
@@ -1164,7 +1168,7 @@ impl AddPrefix for StopLocation {
         self.geometry_id = self
             .geometry_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.equipment_id = self
             .equipment_id
             .take()
@@ -1275,7 +1279,7 @@ impl Calendar {
 
 impl AddPrefix for Calendar {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.id = prefix_conf.referential_prefix(self.id.as_str());
+        self.id = prefix_conf.schedule_prefix(self.id.as_str());
     }
 }
 
@@ -1352,7 +1356,7 @@ impl_id!(Comment);
 
 impl AddPrefix for Comment {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.id = prefix_conf.referential_prefix(self.id.as_str());
+        self.id = prefix_conf.schedule_prefix(self.id.as_str());
     }
 }
 
@@ -1475,7 +1479,7 @@ impl_id!(TripProperty);
 
 impl AddPrefix for TripProperty {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.id = prefix_conf.referential_prefix(self.id.as_str());
+        self.id = prefix_conf.schedule_prefix(self.id.as_str());
     }
 }
 
@@ -1508,7 +1512,7 @@ impl_id!(Geometry);
 
 impl AddPrefix for Geometry {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.id = prefix_conf.referential_prefix(self.id.as_str());
+        self.id = prefix_conf.schedule_prefix(self.id.as_str());
     }
 }
 


### PR DESCRIPTION
Evolution of the `AddPrefix` trait in order to be able to prefix with more information. This evolution is needed for merging together objects of the same contributors that might have the same identifier but are different objects from `transit_model` point-of-view (for example, a `VehicleJourney` that would share the same identifier for the winter service and the summer service).

ref: ND-964