### PR TITLE
[feature] Use schedule_prefix for equipment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.26.0"
+version = "0.26.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1048,7 +1048,7 @@ impl AddPrefix for StopArea {
         self.equipment_id = self
             .equipment_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.geometry_id = self
             .geometry_id
             .take()
@@ -1115,7 +1115,7 @@ impl AddPrefix for StopPoint {
         self.equipment_id = self
             .equipment_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.geometry_id = self
             .geometry_id
             .take()
@@ -1172,7 +1172,7 @@ impl AddPrefix for StopLocation {
         self.equipment_id = self
             .equipment_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
         self.level_id = self
             .level_id
             .take()
@@ -1404,7 +1404,7 @@ impl_id!(Equipment);
 
 impl AddPrefix for Equipment {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        self.id = prefix_conf.referential_prefix(self.id.as_str());
+        self.id = prefix_conf.schedule_prefix(self.id.as_str());
     }
 }
 
@@ -1439,7 +1439,7 @@ impl AddPrefix for Transfer {
         self.equipment_id = self
             .equipment_id
             .take()
-            .map(|id| prefix_conf.referential_prefix(id.as_str()));
+            .map(|id| prefix_conf.schedule_prefix(id.as_str()));
     }
 }
 

--- a/tests/fixtures/gtfs2ntfs/full_output/equipments.txt
+++ b/tests/fixtures/gtfs2ntfs/full_output/equipments.txt
@@ -1,2 +1,2 @@
 equipment_id,wheelchair_boarding,sheltered,elevator,escalator,bike_accepted,bike_depot,visual_announcement,audible_announcement,appropriate_escort,appropriate_signage
-ME:0,1,0,0,0,0,0,0,0,0,0
+ME:Defaul:0,1,0,0,0,0,0,0,0,0,0

--- a/tests/fixtures/gtfs2ntfs/full_output/stops.txt
+++ b/tests/fixtures/gtfs2ntfs/full_output/stops.txt
@@ -1,5 +1,5 @@
 stop_id,stop_name,stop_code,visible,fare_zone_id,stop_lon,stop_lat,location_type,parent_station,stop_timezone,geometry_id,equipment_id,level_id,platform_code
-ME:stop:11,pouet,,1,,2.372987,48.844746,0,ME:stoparea:1,,,ME:0,ME:1,A
+ME:stop:11,pouet,,1,,2.372987,48.844746,0,ME:stoparea:1,,,ME:Defaul:0,ME:1,A
 ME:stop:22,pouet,,1,,2.372987,48.844746,0,ME:stoparea:1,,,,,
 ME:stop:31,pouet,,1,,2.372987,48.844746,0,ME:stoparea:1,,,,,
 ME:stop:32,pouet,,1,,2.372987,48.844746,0,ME:stoparea:1,,,,,


### PR DESCRIPTION
Equipments being auto-generated it is preferable to use the schedule_prefix (instead of referential_prefix) to avoid erroneous assignments to stop_points during a merge.

Ref. ND-980