### PR TITLE
[feature] Full comment deduplication for referential objects, based on name only for similarity

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -810,11 +810,11 @@ impl Collections {
     /// Result: duplicates (comments to be removed) are mapped to their similar
     /// referent (unique to be kept)
     fn get_comment_map_duplicate_to_referent(&self) -> BTreeMap<String, String> {
-        let mut duplicate2ref: BTreeMap<String, String> = BTreeMap::new();
+        let mut duplicate2ref = BTreeMap::<String, String>::new();
         // Map of the referent comments id (uniqueness given the similarity_key)
-        let mut map_ref: BTreeMap<&str, &str> = BTreeMap::new();
+        let mut map_ref = HashMap::<&str, &str>::new();
 
-        for (_, comment) in &self.comments {
+        for comment in self.comments.values() {
             let similarity_key = comment.name.as_str(); // name only is considered
             if let Some(ref_id) = map_ref.get(similarity_key) {
                 duplicate2ref.insert(comment.id.to_string(), ref_id.to_string());

--- a/tests/fixtures/restrict-validity-period/output/comment_links.txt
+++ b/tests/fixtures/restrict-validity-period/output/comment_links.txt
@@ -1,6 +1,6 @@
 object_id,object_type,comment_id
 GDL,stop_area,comment:kept:1
-CHAM,stop_point,comment:kept:2
+CHAM,stop_point,comment:kept:1
 B42,line,comment:kept:1
 M1F,route,comment:kept:1
 M1B1_R,trip,comment:kept:2


### PR DESCRIPTION
Schedule objects are not handled, as no merge is done for them (duplicates would only be the result of initial data).

Ref. ND-979

TODO:

- [x] Check tests are OK for libs depending on this