### PR TITLE
[tech] only use deflate feature of crate zip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tempfile = "3"
 typed_index_collection = "1"
 walkdir = "2"
 wkt = "0.8"
-zip = "0.5"
+zip = { version = "0.5", default-features = false, features = ["deflate"] }
 
 [[test]]
 name = "write_netex_france"


### PR DESCRIPTION
By default the crate `zip` uses features
- deflate
- bzip2 (bindings to libbz2)
- time

We don't use bzip2 and time.