### PR TITLE
[tech] Use action-rs/audit-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,17 @@ jobs:
     - name: Linting
       run: make lint
 
+  audit:
+    name: Audits
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - uses: actions/checkout@v1
+    - name: Security audit
+      uses: actions-rs/audit-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
   tests:
     name: Tests
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
* It visually breaks on vulnerabilities, in forks or not
* It does **not** block merging a PR (`continue-on-error: true` as I think we might end up with some vulnerabilities that we could not immediately deal with, and that are sometimes out of our reach : deps of deps)
* It displays a nice report **only** on main-repo branches, not on forks (but console output is readable anyway)
* It does **not** visually output warnings (one have to search for the report or console output). And no `--deny-warning` available (not sure we would want it anyway as it might be too strict).

Current warnings (no vulnerabilities):
* failure is deprecated/unmaintained (already identified to be replaced)
* term (brought by slog-term) is looking for maintainer since end of 2018

--Comment heavily updated--