### PR TITLE
[feature] Make transit_model::Result generic on Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.31.0"
+version = "0.31.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -34,7 +34,6 @@ use serde::Deserialize;
 use skip_error::skip_error_and_log;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
-use std::result::Result as StdResult;
 use typed_index_collection::{impl_id, Collection, CollectionWithId, Idx};
 
 fn default_agency_id() -> String {
@@ -232,7 +231,7 @@ impl RouteType {
 }
 
 impl ::serde::Serialize for RouteType {
-    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ::serde::Serializer,
     {
@@ -241,7 +240,7 @@ impl ::serde::Serialize for RouteType {
 }
 
 impl<'de> ::serde::Deserialize<'de> for RouteType {
-    fn deserialize<D>(deserializer: D) -> StdResult<RouteType, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<RouteType, D::Error>
     where
         D: ::serde::Deserializer<'de>,
     {
@@ -727,7 +726,7 @@ where
         .from_reader(reader);
     let gtfs_stops: Vec<Stop> = rdr
         .deserialize()
-        .collect::<StdResult<_, _>>()
+        .collect::<Result<_, _>>()
         .with_context(|_| format!("Error reading {:?}", path))?;
 
     let mut stop_areas = vec![];
@@ -1197,10 +1196,10 @@ where
         }
         Some(reader) => {
             let mut rdr = csv::Reader::from_reader(reader);
-            let gtfs_frequencies: Vec<Frequency> =
-                rdr.deserialize()
-                    .collect::<StdResult<_, _>>()
-                    .with_context(|_| format!("Error reading {:?}", path))?;
+            let gtfs_frequencies: Vec<Frequency> = rdr
+                .deserialize()
+                .collect::<Result<_, _>>()
+                .with_context(|_| format!("Error reading {:?}", path))?;
             let mut trip_id_sequence: HashMap<String, u32> = HashMap::new();
             let mut new_vehicle_journeys: Vec<VehicleJourney> = vec![];
             for frequency in &gtfs_frequencies {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,6 @@ lazy_static::lazy_static! {
 pub type Error = failure::Error;
 
 /// The corresponding result type used by the crate.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub use crate::model::Model;

--- a/src/model.rs
+++ b/src/model.rs
@@ -31,7 +31,6 @@ use std::{
     convert::TryFrom,
     iter::FromIterator,
     ops,
-    result::Result as StdResult,
 };
 use typed_index_collection::{Collection, CollectionWithId, Id, Idx};
 
@@ -1197,7 +1196,7 @@ impl Model {
                 })?);
                 Ok((idx, stop_points))
             })
-            .collect::<StdResult<BTreeMap<_, _>, Error>>()?;
+            .collect::<Result<BTreeMap<_, _>, Error>>()?;
         let vehicle_journeys_to_stop_points = ManyToMany::from_forward(forward_vj_to_sp);
         let routes_to_vehicle_journeys =
             OneToMany::new(&c.routes, &c.vehicle_journeys, "routes_to_vehicle_journeys")?;
@@ -1313,7 +1312,7 @@ impl Model {
     }
 }
 impl ::serde::Serialize for Model {
-    fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ::serde::Serializer,
     {
@@ -1321,7 +1320,7 @@ impl ::serde::Serialize for Model {
     }
 }
 impl<'de> ::serde::Deserialize<'de> for Model {
-    fn deserialize<D>(deserializer: D) -> StdResult<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: ::serde::Deserializer<'de>,
     {

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -24,7 +24,6 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::path;
 use std::path::{Path, PathBuf};
-use std::result::Result as StdResult;
 use typed_index_collection::{CollectionWithId, Id};
 
 #[derive(Deserialize, Debug)]
@@ -197,7 +196,7 @@ where
     let mut rdr = csv::Reader::from_reader(reader);
     Ok(rdr
         .deserialize()
-        .collect::<StdResult<_, _>>()
+        .collect::<Result<_, _>>()
         .with_context(|_| format!("Error reading {:?}", path))?)
 }
 
@@ -220,7 +219,7 @@ where
             let mut rdr = csv::Reader::from_reader(reader);
             Ok(rdr
                 .deserialize()
-                .collect::<StdResult<_, _>>()
+                .collect::<Result<_, _>>()
                 .with_context(|_| format!("Error reading {:?}", path))?)
         }
     }


### PR DESCRIPTION
This small PR takes inspiration from [this little tip](https://octodon.social/@rust/104670964806314333).

**Note -** This is not a breaking change even if we change the type `transit_model::Result` which is part of our API.