### PR TITLE
[feature] Improve test utils for report on files count

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -47,7 +47,7 @@ pub fn get_lines_content<P: AsRef<Path>>(path: P) -> BTreeSet<String> {
     set
 }
 
-fn get_files_to_compare<P>(dir: P, files_to_check: Option<&Vec<&str>>) -> Vec<String>
+fn get_files_to_compare<P>(dir: P, files_to_check: Option<&Vec<&str>>) -> BTreeSet<String>
 where
     P: AsRef<Path>,
 {
@@ -57,6 +57,7 @@ where
             .map(|file| file.unwrap())
             .filter(|file| file.path().is_file())
             .map(|file| file.file_name().into_string().unwrap())
+            .filter(|file_name| !file_name.starts_with('.')) // Remove hidden files
             .collect(),
         Some(v) => v.iter().map(|&f| f.to_string()).collect(),
     }
@@ -78,8 +79,7 @@ pub fn compare_output_dir_with_expected_lines<P: AsRef<Path>, Q: AsRef<Path>>(
     let files = get_files_to_compare(&output_dir, files_to_check.as_ref());
     let expected_files = get_files_to_compare(&work_dir_expected, files_to_check.as_ref());
     assert_eq!(
-        files.len(),
-        expected_files.len(),
+        files, expected_files,
         "Different number of produced and expected files"
     );
     for filename in files {


### PR DESCRIPTION
Historically, in our `test_utils` framework, we test the number of files produced vs the number of files in the fixture and compare them. This sometimes leads to something like this kind of error.

![image](https://user-images.githubusercontent.com/2520723/92609037-6030c500-f2b6-11ea-9f41-4ca09fa8a887.png)

This is not very helpful. So I changed it to a comparison of the 2 lists which would show something like this (more helpful I believe). Note that I used a `BTreeSet` instead of a `Vec` so the list is ordered and the diff much more helpful.

![image](https://user-images.githubusercontent.com/2520723/92609423-d6cdc280-f2b6-11ea-993c-83ee62af4f04.png)

As a bonus, hidden files are also filtered. This was inconvenient when you're currently editing a file (like `transfers.txt`) because some editors like `vim` create a swap file (like `.transfers.txt.swp`).