### PR TITLE
[fix] Do not create transfers when geolocation is (0, 0)

### DIFF
--- a/tests/fixtures/transfers/mono_contributor/input/stop_times.txt
+++ b/tests/fixtures/transfers/mono_contributor/input/stop_times.txt
@@ -2,3 +2,4 @@ trip_id,arrival_time,departure_time,stop_id,stop_sequence
 trip:1,15:45:00,15:45:00,sp_1,0
 trip:1,15:46:00,15:46:00,sp_2,1
 trip:1,15:47:00,15:47:00,sp_3,2
+trip:1,15:48:00,15:48:00,sp_4,2

--- a/tests/fixtures/transfers/mono_contributor/input/stops.txt
+++ b/tests/fixtures/transfers/mono_contributor/input/stops.txt
@@ -2,4 +2,5 @@ stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station
 sp_1,sp name 1,48.84608210211328,2.372075915336609,0,sa_1
 sp_2,sp name 2,48.845665532277096,2.371437549591065,0,sa_1
 sp_3,sp name 3,48.845301913401144,2.369517087936402,0,sa_1
+sp_4,sp name 4 (empty geolocation -> no transfer),0.0,0.0,0,sa_1
 sa_1,sa name 1,48.844745,2.372986,1,


### PR DESCRIPTION
When a `StopPoint` geolocation is `(0, 0)`, generating a transfer doesn't make sense and will create weird and incorrect behaviors. This PR prevent the creation of such transfers.

ref: ND-1016.