### PR TITLE
[tech] Bump 0.31.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.31.2"
+version = "0.31.3"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"


### PR DESCRIPTION
For
- [fix] fix short option for gtfs2ntfs #704
- [feature] warning if more than one timezone is reported on agency file #705 
- [tech] Support last version of NeTeX norm #706