### PR TITLE
[fix] Small syntax improvement instead of 'matches'

### DIFF
--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -293,12 +293,7 @@ pub fn manage_stop_times(collections: &mut Collections, path: &path::Path) -> Re
             );
         }
         let datetime_estimated = stop_time.datetime_estimated.map_or_else(
-            || {
-                matches!(
-                    collections.stop_points[stop_point_idx].stop_type,
-                    StopType::Zone
-                )
-            },
+            || collections.stop_points[stop_point_idx].stop_type == StopType::Zone,
             |v| v != 0,
         );
 


### PR DESCRIPTION
Follow-up of https://github.com/CanalTP/transit_model/pull/710#discussion_r502289262.