### PR TITLE
Manage calendar no file handler

### DIFF
--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -293,7 +293,8 @@ where
         on_demand_transport_comment,
     } = configuration;
 
-    manage_calendars(file_handler, &mut collections)?;
+    let ntfs_path = read_utils::FileHandler::as_path_buf(&mut *file_handler);
+    manage_calendars(ntfs_path, &mut collections)?;
     validity_period::compute_dataset_validity_period(&mut dataset, &collections.calendars)?;
 
     collections.contributors = CollectionWithId::from(contributor);

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -2075,7 +2075,7 @@ mod tests {
             collections.comments = comments;
             super::read_routes(&mut handler, &mut collections).unwrap();
             super::manage_shapes(&mut collections, &mut handler).unwrap();
-            calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+            calendars::manage_calendars(path, &mut collections).unwrap();
 
             let mut prefix_conf = PrefixConfiguration::default();
             prefix_conf.set_data_prefix("my_prefix");
@@ -2770,11 +2770,10 @@ mod tests {
                        2,1,0,0,0,0,0,0,20180502,20180506";
 
         test_in_tmp_dir(|path| {
-            let mut handler = PathFileHandler::new(path.to_path_buf());
             create_file_with_content(path, "calendar.txt", content);
 
             let mut collections = Collections::default();
-            calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+            calendars::manage_calendars(path, &mut collections).unwrap();
 
             let mut dates = BTreeSet::new();
             dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 5));
@@ -2797,11 +2796,10 @@ mod tests {
                        2,20180211,2";
 
         test_in_tmp_dir(|path| {
-            let mut handler = PathFileHandler::new(path.to_path_buf());
             create_file_with_content(path, "calendar_dates.txt", content);
 
             let mut collections = Collections::default();
-            calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+            calendars::manage_calendars(path, &mut collections).unwrap();
 
             let mut dates = BTreeSet::new();
             dates.insert(chrono::NaiveDate::from_ymd(2018, 2, 12));
@@ -2827,13 +2825,12 @@ mod tests {
                                       2,20180506,2";
 
         test_in_tmp_dir(|path| {
-            let mut handler = PathFileHandler::new(path.to_path_buf());
             create_file_with_content(path, "calendar.txt", calendars_content);
 
             create_file_with_content(path, "calendar_dates.txt", calendar_dates_content);
 
             let mut collections = Collections::default();
-            calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+            calendars::manage_calendars(path, &mut collections).unwrap();
 
             let mut dates = BTreeSet::new();
             dates.insert(chrono::NaiveDate::from_ymd(2018, 5, 6));
@@ -2858,9 +2855,8 @@ mod tests {
     #[should_panic(expected = "calendar_dates.txt or calendar.txt not found")]
     fn gtfs_without_calendar_dates_or_calendar() {
         test_in_tmp_dir(|path| {
-            let mut handler = PathFileHandler::new(path.to_path_buf());
             let mut collections = Collections::default();
-            calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+            calendars::manage_calendars(path, &mut collections).unwrap();
         });
     }
 

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -708,7 +708,6 @@ mod tests {
     use super::*;
     use crate::calendars;
     use crate::objects;
-    use crate::read_utils;
     use crate::test_utils::*;
     use pretty_assertions::assert_eq;
 
@@ -793,7 +792,6 @@ mod tests {
             create_file_with_content(path, "stop_times.txt", stop_times_content);
 
             let mut collections = Collections::default();
-            let mut file_handle = read_utils::PathFileHandler::new(path.to_path_buf());
             collections.contributors = make_collection_with_id(path, "contributors.txt").unwrap();
             collections.datasets = make_collection_with_id(path, "datasets.txt").unwrap();
             collections.commercial_modes =
@@ -805,7 +803,7 @@ mod tests {
             collections.physical_modes =
                 make_collection_with_id(path, "physical_modes.txt").unwrap();
             collections.companies = make_collection_with_id(path, "companies.txt").unwrap();
-            calendars::manage_calendars(&mut file_handle, &mut collections).unwrap();
+            calendars::manage_calendars(path, &mut collections).unwrap();
             manage_stops(&mut collections, path).unwrap();
             manage_stop_times(&mut collections, path).unwrap();
 

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -108,6 +108,10 @@ where
             path,
         ))
     }
+
+    fn as_path_buf(self) -> PathBuf {
+        self.get_file_if_exists("").unwrap().1
+    }
 }
 
 /// PathFileHandler is used to read files for a directory

--- a/src/validity_period.rs
+++ b/src/validity_period.rs
@@ -142,12 +142,7 @@ mod tests {
 
     mod compute_dataset_validity_period {
         use super::super::*;
-        use crate::{
-            calendars,
-            model::Collections,
-            read_utils::{self, PathFileHandler},
-            test_utils::*,
-        };
+        use crate::{calendars, model::Collections, read_utils, test_utils::*};
 
         #[test]
         fn test_compute_dataset_validity_period() {
@@ -159,14 +154,13 @@ mod tests {
                                       2,20180520,2";
 
             test_in_tmp_dir(|path| {
-                let mut handler = PathFileHandler::new(path.to_path_buf());
                 create_file_with_content(path, "calendar.txt", calendars_content);
                 create_file_with_content(path, "calendar_dates.txt", calendar_dates_content);
 
                 let mut collections = Collections::default();
                 let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
-                calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+                calendars::manage_calendars(path, &mut collections).unwrap();
                 compute_dataset_validity_period(&mut dataset, &collections.calendars).unwrap();
 
                 assert_eq!(
@@ -191,13 +185,12 @@ mod tests {
                                  1,1,1,1,1,1,0,0,20180501,20180501";
 
             test_in_tmp_dir(|path| {
-                let mut handler = PathFileHandler::new(path.to_path_buf());
                 create_file_with_content(path, "calendar.txt", calendars_content);
 
                 let mut collections = Collections::default();
                 let (_, mut dataset, _) = read_utils::read_config(None::<&str>).unwrap();
 
-                calendars::manage_calendars(&mut handler, &mut collections).unwrap();
+                calendars::manage_calendars(path, &mut collections).unwrap();
                 compute_dataset_validity_period(&mut dataset, &collections.calendars).unwrap();
 
                 assert_eq!(


### PR DESCRIPTION
This PR depends on #714 which needs to be merged first.

In this PR, `transit_model::calendars::manage_calendars()` is refactored to take a `AsRef<Path>` as input parameter instead of a `FileHandler`.

In order to make it work, I introduced a `FileHandler::as_path_buf()` method for now. I hope this will help us during the work of removing `FileHandler` bit-by-bit, especially in functions that receive a `FileHandler` but need to call sub-functions with a `AsRef<Path>` (which is the case now in `transit_model::gtfs::read()` that calls `transit_model::calendars::manage_calendars()`). In the end, `FileHandler` will disappear anyway so this is only a temporary helper for the transition.

ref: ND-956.