### PR TITLE
keep forbidden pickup/dropoff on stay in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.33.0"
+version = "0.33.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ exclude = [
 	"CONTRIBUTING.md",
 	"README.md",
 	"examples/",
-	"model-builder/",
 	"src/documentation/",
 	"tests/",
 ]
@@ -26,6 +25,7 @@ members = [
 	"gtfs2ntfs",
 	"ntfs2gtfs",
 	"ntfs2netexfr",
+	"model-builder",
 	"ntfs2ntfs",
 	"restrict-validity-period",
 ]
@@ -71,3 +71,4 @@ required-features = ["proj"]
 approx = "0.3"
 rust_decimal_macros = "1"
 testing_logger = "0.1"
+transit_model_builder = { path = "./model-builder"}

--- a/model-builder/Cargo.toml
+++ b/model-builder/Cargo.toml
@@ -5,6 +5,11 @@ authors = ["Antoine Desbordes <antoine.desbordes@gmail.com>"]
 edition = "2018"
 license = "AGPL-3.0-only"
 description = "A crate to easily build a transit_model::Model"
+repository = "https://github.com/CanalTP/transit_model"
+homepage = "https://github.com/CanalTP/transit_model"
+readme = "README.md"
+categories = ["data-structures"]
+keywords = ["transit"]
 
 [dependencies]
 # Swap the next two lines when publishing

--- a/model-builder/src/builder.rs
+++ b/model-builder/src/builder.rs
@@ -73,8 +73,10 @@ impl<'a> ModelBuilder {
     where
         F: FnMut(VehicleJourneyBuilder),
     {
-        let mut new_vj = VehicleJourney::default();
-        new_vj.id = name.into();
+        let new_vj = VehicleJourney {
+            id: name.into(),
+            ..Default::default()
+        };
         let vj_idx = self
             .collections
             .vehicle_journeys

--- a/model-builder/src/builder.rs
+++ b/model-builder/src/builder.rs
@@ -233,7 +233,7 @@ impl IntoTime for &Time {
 impl IntoTime for &str {
     // Note: if the string is not in the right format, this conversion will fail
     fn into_time(self) -> Time {
-        self.parse().unwrap()
+        self.parse().expect("invalid time format")
     }
 }
 

--- a/model-builder/src/builder.rs
+++ b/model-builder/src/builder.rs
@@ -123,6 +123,8 @@ impl<'a> ModelBuilder {
 
     /// Add a new Calendar or change an existing one
     ///
+    /// Note: if the date are in strings not in the right format, this conversion will fail
+    ///
     /// ```
     /// # use transit_model::objects::Date;
     ///
@@ -286,6 +288,9 @@ impl<'a> VehicleJourneyBuilder<'a> {
     }
 
     /// add a StopTime to the vehicle journey
+    ///
+    /// Note: if the arrival/departure are given in string
+    /// not in the right format, this conversion will fail
     ///
     /// ```
     /// # fn main() {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1894,7 +1894,7 @@ mod tests {
         }
 
         #[test]
-        fn block_id_on_overlaping_calendar_ok() {
+        fn block_id_on_overlapping_calendar_ok() {
             // like the example 4 but on less days
             // working days:
             // days: 01 02 03 04

--- a/src/model.rs
+++ b/src/model.rs
@@ -1954,7 +1954,7 @@ mod tests {
         }
 
         #[test]
-        fn block_id_on_overlaping_calendar_forbidden_pickup() {
+        fn block_id_on_overlapping_calendar_forbidden_pickup() {
             // like the example 4 but on less days
             // working days:
             // days: 01 02 03 04

--- a/src/model.rs
+++ b/src/model.rs
@@ -1835,6 +1835,48 @@ mod tests {
             assert_eq!(1, stop_time.pickup_type);
             assert_eq!(0, stop_time.drop_off_type);
         }
+
+        #[test]
+        fn forbidden_drop_off_should_be_kept() {
+            let model = transit_model_builder::ModelBuilder::default()
+                .vj("vj1", |vj| {
+                    vj.block_id("block_1")
+                        .st_init("SP1", "10:00:00", "10:01:00", |st| {
+                            st.pickup_type = 1;
+                            st.drop_off_type = 1;
+                        })
+                        .st_init("SP2", "11:00:00", "11:01:00", |st| {
+                            st.pickup_type = 1;
+                            st.drop_off_type = 1;
+                        });
+                })
+                .vj("vj2", |vj| {
+                    vj.block_id("block_1")
+                        .st_init("SP3", "12:00:00", "12:01:00", |st| {
+                            st.pickup_type = 1;
+                            st.drop_off_type = 1;
+                        })
+                        .st_init("SP4", "13:00:00", "13:01:00", |st| {
+                            st.pickup_type = 1;
+                            st.drop_off_type = 1;
+                        });
+                })
+                .build();
+            let vj1 = model.vehicle_journeys.get("vj1").unwrap();
+            let stop_time = &vj1.stop_times[0];
+            assert_eq!(1, stop_time.pickup_type); //should still forbidden
+            assert_eq!(1, stop_time.drop_off_type);
+            let stop_time = &vj1.stop_times[vj1.stop_times.len() - 1];
+            assert_eq!(1, stop_time.pickup_type);
+            assert_eq!(1, stop_time.drop_off_type); //should still forbidden
+            let vj2 = model.vehicle_journeys.get("vj2").unwrap();
+            let stop_time = &vj2.stop_times[0];
+            assert_eq!(1, stop_time.pickup_type); //should still forbidden
+            assert_eq!(1, stop_time.drop_off_type);
+            let stop_time = &vj2.stop_times[vj2.stop_times.len() - 1];
+            assert_eq!(1, stop_time.pickup_type);
+            assert_eq!(1, stop_time.drop_off_type); //should still forbidden
+        }
     }
 
     mod enhance_trip_headsign {

--- a/src/model.rs
+++ b/src/model.rs
@@ -2020,6 +2020,7 @@ mod tests {
             // days: 01 02 03
             // VJ:1   X  X
             // VJ:2         X
+            // The pick-up (resp drop-off) at first (resp last) stop should be forbidden
             let model = transit_model_builder::ModelBuilder::default()
                 .calendar("c1", &["2020-01-01", "2020-01-02"])
                 .calendar("c2", &["2020-01-03"])

--- a/src/model.rs
+++ b/src/model.rs
@@ -1746,10 +1746,10 @@ mod tests {
             collections.vehicle_journeys =
                 build_vehicle_journeys(stop_config, next_vj_config_config);
             let mut dates = std::collections::BTreeSet::new();
-            dates.insert(Date::from_ymd(2020, 01, 01));
+            dates.insert(Date::from_ymd(2020, 1, 1));
             collections.calendars = CollectionWithId::new(vec![Calendar {
                 id: "default_service".to_owned(),
-                dates: dates,
+                dates,
             }])
             .unwrap();
             collections.enhance_pickup_dropoff();
@@ -1788,10 +1788,10 @@ mod tests {
             collections.vehicle_journeys =
                 build_vehicle_journeys(stop_config, next_vj_config_config);
             let mut dates = std::collections::BTreeSet::new();
-            dates.insert(Date::from_ymd(2020, 01, 01));
+            dates.insert(Date::from_ymd(2020, 1, 1));
             collections.calendars = CollectionWithId::new(vec![Calendar {
                 id: "default_service".to_owned(),
-                dates: dates,
+                dates,
             }])
             .unwrap();
             collections.enhance_pickup_dropoff();
@@ -1830,10 +1830,10 @@ mod tests {
             collections.vehicle_journeys =
                 build_vehicle_journeys(stop_config, next_vj_config_config);
             let mut dates = std::collections::BTreeSet::new();
-            dates.insert(Date::from_ymd(2020, 01, 01));
+            dates.insert(Date::from_ymd(2020, 1, 1));
             collections.calendars = CollectionWithId::new(vec![Calendar {
                 id: "default_service".to_owned(),
-                dates: dates,
+                dates,
             }])
             .unwrap();
             collections.enhance_pickup_dropoff();

--- a/src/model.rs
+++ b/src/model.rs
@@ -1961,7 +1961,7 @@ mod tests {
             // VJ:1   X  X  X  X
             // VJ:2   X  X  X
             // VJ:3            X
-            // VJ:1 has a forbidden pick up at 2 that should be kept
+            // VJ:1 has a forbidden pick up at the 2nd stop-time that should be kept
             let model = transit_model_builder::ModelBuilder::default()
                 .calendar("c1", "2020-01-01")
                 .calendar("c1", "2020-01-02")

--- a/src/model.rs
+++ b/src/model.rs
@@ -1876,7 +1876,7 @@ mod tests {
             let vj1 = model.vehicle_journeys.get("vj1").unwrap();
             let stop_time = &vj1.stop_times[0];
             assert_eq!(0, stop_time.pickup_type);
-            assert_eq!(1, stop_time.drop_off_type); // it has not been explicitly changed so the 1st drop_off is forbiden
+            assert_eq!(1, stop_time.drop_off_type); // it has not been explicitly changed so the 1st drop_off is forbidden
                                                     // the vj should have the last st pickup forbidden even if it's a
                                                     // stay in because it was explicitly forbidden
             let stop_time = &vj1.stop_times[vj1.stop_times.len() - 1];

--- a/src/model.rs
+++ b/src/model.rs
@@ -795,8 +795,8 @@ impl Collections {
     /// Example 4 is a valid use case of stay-in
     /// The pickup/dropoff will be possible between VJ:1 and VJ:2/VJ:3
     pub fn enhance_pickup_dropoff(&mut self) {
-        let mut allowed_last_pick_up_vj = HashSet::<_>::new();
-        let mut allowed_first_drop_off_vj = HashSet::<_>::new();
+        let mut allowed_last_pick_up_vj = HashSet::new();
+        let mut allowed_first_drop_off_vj = HashSet::new();
 
         let can_chain_without_overlap = |prev_vj: &VehicleJourney, next_vj: &VehicleJourney| {
             let last_stop = &prev_vj.stop_times.last();

--- a/src/model.rs
+++ b/src/model.rs
@@ -1879,7 +1879,7 @@ mod tests {
             assert_eq!(1, stop_time.drop_off_type); // it has not been explicitly changed so the 1st drop_off is forbidden
                                                     // the vj should have the last st pickup forbidden even if it's a
                                                     // stay in because it was explicitly forbidden
-            let stop_time = &vj1.stop_times[vj1.stop_times.len() - 1];
+            let stop_time = &vj1.stop_times.last().unwrap();
             assert_eq!(1, stop_time.pickup_type);
             assert_eq!(1, stop_time.drop_off_type);
             let vj2 = model.vehicle_journeys.get("vj2").unwrap();

--- a/src/model.rs
+++ b/src/model.rs
@@ -751,7 +751,7 @@ impl Collections {
     ///                         |- Stay-In -|
     ///
     /// In this example the stop SP2 is in both VJ, so we can forbid the pick-up
-    /// for VJ:1 / drop-off for VJ:2 since we don't want to tell a traveller to take VJ:1
+    /// for VJ:1 / drop-off for VJ:2 since we don't want to tell a traveler to take VJ:1
     /// at SP2 but VJ:2
     ///
     /// Example 2:

--- a/src/model.rs
+++ b/src/model.rs
@@ -1906,13 +1906,9 @@ mod tests {
             // VJ:3 can sometimes be taken after VJ:1 so we also don't want to forbid
             // pick-up at last stop / drop-off at 1st stop
             let model = transit_model_builder::ModelBuilder::default()
-                .calendar("c1", "2020-01-01")
-                .calendar("c1", "2020-01-02")
-                .calendar("c1", "2020-01-03")
-                .calendar("c2", "2020-01-01")
-                .calendar("c2", "2020-01-02")
-                .calendar("c3", "2020-01-03")
-                .calendar("c3", "2020-01-04")
+                .calendar("c1", &["2020-01-01", "2020-01-02", "2020-01-03"])
+                .calendar("c2", &["2020-01-01", "2020-01-02"])
+                .calendar("c3", &["2020-01-03", "2020-01-04"])
                 .vj("VJ:1", |vj| {
                     vj.block_id("block_1")
                         .calendar("c1")
@@ -1966,14 +1962,12 @@ mod tests {
             // VJ:3            X
             // VJ:1 has a forbidden pick up at the 2nd stop-time that should be kept
             let model = transit_model_builder::ModelBuilder::default()
-                .calendar("c1", "2020-01-01")
-                .calendar("c1", "2020-01-02")
-                .calendar("c1", "2020-01-03")
-                .calendar("c1", "2020-01-04")
-                .calendar("c2", "2020-01-01")
-                .calendar("c2", "2020-01-02")
-                .calendar("c2", "2020-01-03")
-                .calendar("c3", "2020-01-04")
+                .calendar(
+                    "c1",
+                    &["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"],
+                )
+                .calendar("c2", &["2020-01-01", "2020-01-02", "2020-01-03"])
+                .calendar("c3", &["2020-01-04"])
                 .vj("VJ:1", |vj| {
                     vj.block_id("block_1")
                         .calendar("c1")
@@ -2027,9 +2021,8 @@ mod tests {
             // VJ:1   X  X
             // VJ:2         X
             let model = transit_model_builder::ModelBuilder::default()
-                .calendar("c1", "2020-01-01")
-                .calendar("c1", "2020-01-02")
-                .calendar("c2", "2020-01-03")
+                .calendar("c1", &["2020-01-01", "2020-01-02"])
+                .calendar("c2", &["2020-01-03"])
                 .vj("VJ:1", |vj| {
                     vj.block_id("block_1")
                         .calendar("c1")
@@ -2062,7 +2055,7 @@ mod tests {
 
         #[test]
         fn block_id_on_non_overlaping_calendar_with_overlaping_stops() {
-            // tricky test case when there is no good response
+            // tricky test case when there is no perfect response
             //
             // working days:
             // days: 01 02
@@ -2080,10 +2073,9 @@ mod tests {
             // VJ:1 - VJ:3
             // we can however forbid the drop-off on VJ:3 at SP:2
             let model = transit_model_builder::ModelBuilder::default()
-                .calendar("c1", "2020-01-01")
-                .calendar("c1", "2020-01-02")
-                .calendar("c2", "2020-01-01")
-                .calendar("c3", "2020-01-02")
+                .calendar("c1", &["2020-01-01", "2020-01-02"])
+                .calendar("c2", &["2020-01-01"])
+                .calendar("c3", &["2020-01-02"])
                 .vj("VJ:1", |vj| {
                     vj.block_id("block_1")
                         .calendar("c1")

--- a/src/model.rs
+++ b/src/model.rs
@@ -811,7 +811,7 @@ impl Collections {
                         let prev_cal = self.calendars.get(&prev_vj.service_id);
                         let next_cal = self.calendars.get(&next_vj.service_id);
                         // for the stay in to be possible the vj should have at least one date in common
-                        prev_cal.map_or(false, |prev_cal| next_cal.map_or(false, |next_cal|prev_cal.overlaps(&next_cal))) &&
+                        prev_cal.map_or(false, |prev_cal| next_cal.map_or(false, |next_cal| prev_cal.overlaps(&next_cal))) &&
                         // The stay in is not really possible when timing overlaps
                         // between arrival of first vehicle journey and departure of
                         // next vehicle journey (see Example 2 above).

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1286,6 +1286,11 @@ impl Calendar {
             dates: BTreeSet::new(),
         }
     }
+
+    /// Returns true if the calendars have at least one date in common
+    pub fn overlaps(&self, other: &Self) -> bool {
+        !self.dates.is_disjoint(&other.dates)
+    }
 }
 
 impl AddPrefix for Calendar {


### PR DESCRIPTION
To keep to data as clean as possible, the model was sanitized to add restrictions on drop off at first stop time / pick up at last stop time.
Since for stay in this could remove valid journeys, the pick up at last stop time / drop off at first stop time was possible for stay in.

The previous implementation was removing explicitly set constraints on those stay in stop times.
As a side effect we now also correctly handle restrictions on stay in of different calendars (see [example 4](https://github.com/antoine-de/navitia_model/blob/fae185abe7d36cee8648ee45799853220466abd1/src/model.rs#L787-L796))


Note 1: the new implementation is quadratic in term of trip on the same `block_id`. However the number of vj on the same block_id seems quite limited thus the runtime penalty is quite small.
I tested it on [the bretagne dataset](https://transport.data.gouv.fr/datasets/base-de-donnees-multimodale-transports-publics-en-bretagne-mobibreizh/), so biggest dataset I know with block_id (106k trips, 2M+ stoptimes, max number of vehicle journeys with same block_id: 76) there is a small impact on the run time import (not on the memory footprint).
On my computer the best of 3 runs (there are ~1s of difference on the same runs) before: 17s to read the GTFS, after: 18s to read the GTFS.

Note 2:
this reactivate the use of the model_builder and add some utilities to it

internally linked to ND-1088