### PR TITLE
add a gtfs::from_read method

### DIFF
--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -142,16 +142,18 @@ impl<'a, P: AsRef<Path>> FileHandler for &'a mut PathFileHandler<P> {
 /// Unlike ZipArchive, it gives access to a file by its name not regarding its path in the ZipArchive
 /// It thus cannot be correct if there are 2 files with the same name in the archive,
 /// but for transport data if will make it possible to handle a zip with a sub directory
-pub(crate) struct ZipHandler {
-    archive: zip::ZipArchive<File>,
+pub(crate) struct ZipHandler<R: std::io::Seek + std::io::Read> {
+    archive: zip::ZipArchive<R>,
     archive_path: PathBuf,
     index_by_name: BTreeMap<String, usize>,
 }
 
-impl ZipHandler {
-    pub(crate) fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = File::open(path.as_ref())?;
-        let mut archive = zip::ZipArchive::new(file)?;
+impl<R> ZipHandler<R>
+where
+    R: std::io::Seek + std::io::Read,
+{
+    pub(crate) fn new<P: AsRef<Path>>(r: R, path: P) -> Result<Self> {
+        let mut archive = zip::ZipArchive::new(r)?;
         Ok(ZipHandler {
             index_by_name: Self::files_by_name(&mut archive),
             archive,
@@ -159,7 +161,7 @@ impl ZipHandler {
         })
     }
 
-    fn files_by_name(archive: &mut zip::ZipArchive<File>) -> BTreeMap<String, usize> {
+    fn files_by_name(archive: &mut zip::ZipArchive<R>) -> BTreeMap<String, usize> {
         (0..archive.len())
             .filter_map(|i| {
                 let file = archive.by_index(i).ok()?;
@@ -172,7 +174,10 @@ impl ZipHandler {
     }
 }
 
-impl<'a> FileHandler for &'a mut ZipHandler {
+impl<'a, R> FileHandler for &'a mut ZipHandler<R>
+where
+    R: std::io::Seek + std::io::Read,
+{
     type Reader = zip::read::ZipFile<'a>;
     fn get_file_if_exists(self, name: &str) -> Result<(Option<Self::Reader>, PathBuf)> {
         let p = self.archive_path.join(name);
@@ -273,8 +278,9 @@ mod tests {
 
     #[test]
     fn zip_file_handler() {
-        let mut file_handler =
-            ZipHandler::new(PathBuf::from("tests/fixtures/file-handler.zip")).unwrap();
+        let p = "tests/fixtures/file-handler.zip";
+        let reader = File::open(p).unwrap();
+        let mut file_handler = ZipHandler::new(reader, p).unwrap();
 
         {
             let (mut hello, _) = file_handler.get_file("hello.txt").unwrap();


### PR DESCRIPTION
closes https://github.com/CanalTP/transit_model/issues/737

Add a `gtfs::from_read` method to be able to read gtfs from various
sources (like from the network).

this makes it possible to read a gtfs like
```rust
let url = "http://some_url/gtfs.zip";
let resp = reqwest::blocking::get(url)?; // or async call
let data = std::io::Cursor::new(resp.bytes()?.to_vec());
let model = transit_model::gtfs::from_read(data, &url, configuration)?;
```