### PR TITLE
handle route comments on line when using read_as_line

### DIFF
--- a/documentation/gtfs_to_ntfs_specs.md
+++ b/documentation/gtfs_to_ntfs_specs.md
@@ -188,7 +188,7 @@ _Warning :_ If the GTFS route has no trips, the Navitia Route should NOT be crea
 | routes.txt   | direction_type | Optional   |            |                 | (2)                                                                                                                                                         |
 | routes.txt   | line_id        | Required   |            |                 | corresponding `line.id` (see Line construction above)                                                                                                       |
 | routes.txt   | destination_id | Optional   |            |                 | This field contains a stop_area.id of the most frequent destination of the contained trips (ie. the parent_station of the most frequent last stop of trips) |
-| comments.txt | comment_value  | Optional   | routes.txt | route_desc      | See (3) for additional properties                                                                                                                           |
+| comments.txt | comment_value  | Optional   | routes.txt | route_desc      | The comment is generated only when the parameter `read-as-line` is deactivated. See (3) for additional properties                                                                                                                           |
 
 (1) if only one route is created (only one direction in included trips), use
 `route_long_name` or, if empty, use `route_short_name`. In case of multiple
@@ -219,8 +219,14 @@ specified, the conversion should stop immediately with an error.
 | lines.txt | line_text_color    | Optional   | routes.txt | route_text_color | same as line_color; if color format is incorrect, the value is dropped                                                                                                                                                                                                           |
 | lines.txt | line_sort_order    | Optional   | routes.txt | route_sort_order |                                                                                                                                                                                                                                                                                  |
 | lines.txt | commercial_mode_id | Required   | routes.txt | route_type       | See "Mapping of route_type with modes" chapter (1).                                                                                                                                                                                                                              |
+| comments.txt | comment_value | Optional | routes.txt | route_desc | The comment is generated only when the parameter `read-as-line` is activated. See (2) for additional properties. |
 
 (1) When several GTFS Routes with different `route_type`s are grouped together, the commercial_mode_id with the smallest priority should be used (as specified in chapter "Mapping of route_type with modes").
+
+(2) The `comment` object is a complex type with additional properties :
+
+* `comment_id` : specify an identifier with the pattern **\<prefix>:line:<route_id of GTFS>**
+* `comment_type` : specify the fixed value "Information"
 
 ### Reading calendars.txt and calendar_dates.txt
 

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/calendar.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/calendar.txt
@@ -1,0 +1,3 @@
+service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
+service:1,1,1,1,0,0,0,0,20180101,20180103
+service:2,0,0,0,0,1,1,0,20180105,20180106

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/comment_links.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/comment_links.txt
@@ -1,0 +1,4 @@
+object_id,object_type,comment_id
+route:2,line,line:route:2
+stoparea:1,stop_area,stop:stoparea:1
+stop:11,stop_point,stop:stop:11

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/comments.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/comments.txt
@@ -1,0 +1,4 @@
+comment_id,comment_type,comment_label,comment_name,comment_url
+stop:stoparea:1,information,,stoparea:1_comment,
+stop:stop:11,information,,stop:11_comment,
+line:route:2,information,,route 2 comment,

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/commercial_modes.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/commercial_modes.txt
@@ -1,0 +1,2 @@
+commercial_mode_id,commercial_mode_name
+Metro,Metro

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/companies.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/companies.txt
@@ -1,0 +1,3 @@
+company_id,company_name,company_address,company_url,company_mail,company_phone
+1,mon agence,,http://kisio.org,,
+2,my agency,,http://kisio.org,,0123456789

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/contributors.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/contributors.txt
@@ -1,0 +1,2 @@
+contributor_id,contributor_name,contributor_license,contributor_website
+default_contributor,Default contributor,Unknown license,

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/datasets.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/datasets.txt
@@ -1,0 +1,2 @@
+dataset_id,contributor_id,dataset_start_date,dataset_end_date,dataset_type,dataset_extrapolation,dataset_desc,dataset_system
+default_dataset,default_contributor,20180101,20180106,,0,,

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/feed_infos.txt
@@ -1,0 +1,7 @@
+feed_info_param,feed_info_value
+feed_creation_date,20190403
+feed_creation_time,17:19:00
+feed_creation_datetime,2019-04-03T17:19:00+00:00
+feed_end_date,20180106
+feed_start_date,20180101
+ntfs_version,0.11.4

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/lines.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/lines.txt
@@ -1,0 +1,3 @@
+line_id,line_code,line_name,forward_line_name,backward_line_name,line_color,line_text_color,line_sort_order,network_id,commercial_mode_id,geometry_id,line_opening_time,line_closing_time
+route:2,ma route 1,,,,,,,1,Metro,,23:50:00,31:40:00
+route:3,ma route 2,,,,,,,2,Metro,,13:23:00,15:20:00

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/networks.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/networks.txt
@@ -1,0 +1,3 @@
+network_id,network_name,network_url,network_timezone,network_lang,network_phone,network_address,network_sort_order
+1,mon agence,http://kisio.org,Europe/Paris,,,,
+2,my agency,http://kisio.org,Europe/Paris,,0123456789,,

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/object_codes.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/object_codes.txt
@@ -1,0 +1,17 @@
+object_type,object_id,object_system,object_code
+stop_area,stoparea:1,source,stoparea:1
+stop_point,stop:11,source,stop:11
+stop_point,stop:22,source,stop:22
+stop_point,stop:31,source,stop:31
+stop_point,stop:32,source,stop:32
+stop_point,stop:33,source,stop:33
+stop_point,stop:51,source,stop:51
+stop_point,stop:52,source,stop:52
+stop_point,stop:53,source,stop:53
+stop_point,stop:61,source,stop:61
+network,1,source,1
+network,2,source,2
+trip,trip:4,source,trip:4
+trip,trip:5,source,trip:5
+trip,trip:3,source,trip:3
+trip,trip:6,source,trip:6

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/physical_modes.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/physical_modes.txt
@@ -1,0 +1,5 @@
+physical_mode_id,physical_mode_name,co2_emission
+Metro,Metro,3.0
+Bike,Bike,0.0
+BikeSharingService,BikeSharingService,0.0
+Car,Car,184.0

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/routes.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/routes.txt
@@ -1,0 +1,3 @@
+route_id,route_name,direction_type,line_id,geometry_id,destination_id
+route:2,ma route 1,forward,route:2,,stoparea:1
+route:3,ma route 2,forward,route:3,,stoparea:1

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/stop_times.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/stop_times.txt
@@ -1,0 +1,12 @@
+stop_id,trip_id,stop_sequence,arrival_time,departure_time,boarding_duration,alighting_duration,pickup_type,drop_off_type,datetime_estimated,local_zone_id,stop_headsign,stop_time_id,stop_time_precision
+stop:11,trip:4,0,07:23:00,07:23:00,0,0,2,1,0,,,,0
+stop:22,trip:4,1,07:32:00,07:32:00,0,0,2,0,0,,,,0
+stop:33,trip:4,2,07:40:00,07:42:00,0,0,1,0,0,,,,0
+stop:51,trip:5,0,13:23:00,13:23:00,0,0,2,1,0,,,,0
+stop:52,trip:5,1,14:10:00,14:10:00,0,0,2,0,0,,,,0
+stop:53,trip:5,2,14:40:00,14:40:00,0,0,1,2,0,,,,0
+stop:31,trip:3,0,23:50:00,23:50:00,0,0,0,1,0,,,,0
+stop:32,trip:3,1,24:03:00,24:05:00,0,0,0,0,0,,,,0
+stop:33,trip:3,2,24:10:00,24:15:00,0,0,1,0,0,,,,0
+stop:61,trip:6,0,14:40:00,14:40:00,0,0,2,1,0,,,,0
+stop:61,trip:6,1,15:20:00,15:20:00,0,0,1,0,0,,,,0

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/stops.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/stops.txt
@@ -1,0 +1,11 @@
+stop_id,stop_name,stop_code,visible,fare_zone_id,stop_lon,stop_lat,location_type,parent_station,stop_timezone,geometry_id,equipment_id,level_id,platform_code
+stop:11,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:22,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:31,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:32,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:33,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:51,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:52,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:53,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stop:61,pouet,,1,,2.372987,48.844746,0,stoparea:1,,,,,
+stoparea:1,plop,,1,,2.372987,48.844746,1,,,,,,

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/trips.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/trips.txt
@@ -1,0 +1,5 @@
+trip_id,route_id,physical_mode_id,dataset_id,service_id,trip_headsign,trip_short_name,block_id,company_id,trip_property_id,geometry_id,journey_pattern_id
+trip:4,route:2,Metro,default_dataset,service:1,pouet,,,1,,,
+trip:5,route:3,Metro,default_dataset,service:2,pouet,,,2,,,
+trip:3,route:2,Metro,default_dataset,service:1,pouet,,,1,,,
+trip:6,route:3,Metro,default_dataset,service:2,pouet,,,2,,,

--- a/tests/gtfs2ntfs.rs
+++ b/tests/gtfs2ntfs.rs
@@ -193,3 +193,21 @@ fn test_minimal_gtfs_with_routes_comments() {
         );
     });
 }
+
+#[test]
+fn test_minimal_gtfs_with_routes_as_lines_comments() {
+    test_in_tmp_dir(|path| {
+        let input_dir = "./tests/fixtures/gtfs2ntfs/routes_comments/input";
+        let configuration = gtfs::Configuration {
+            read_as_line: true,
+            ..Default::default()
+        };
+        let model = gtfs::read_from_path(input_dir, configuration).unwrap();
+        ntfs::write(&model, path, get_test_datetime()).unwrap();
+        compare_output_dir_with_expected(
+            &path,
+            None,
+            "./tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines",
+        );
+    });
+}


### PR DESCRIPTION
cf. ND-1075 and replaces #736 