### PR TITLE
[ci] use 'rust-ci:latest-proj'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,40 +8,25 @@ jobs:
   rustfmt:
     name: Formatting check
     runs-on: ubuntu-latest
+    container: kisiodigital/rust-ci:latest
     steps:
     - uses: actions/checkout@master
-    - name: Install Rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt
     - name: Check formatting
       run: make format
 
   clippy:
     name: Analyzing code with Clippy
     runs-on: ubuntu-latest
+    container: kisiodigital/rust-ci:latest-proj
     steps:
-    - name: Install proj
-      run: |
-        wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | sudo apt-key add -
-        echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" | sudo tee /etc/apt/sources.list.d/kisio-digital.list
-        sudo apt update
-        sudo apt install --yes pkg-config libssl-dev clang libtiff-dev libcurl4-nss-dev proj=${PROJ_VERSION}
     - uses: actions/checkout@master
-    - name: Install Rust stable
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          profile: minimal
-          components: clippy
     - name: Linting
       run: make lint
 
   audit:
     name: Audits
     runs-on: ubuntu-latest
+    container: kisiodigital/rust-ci:latest-proj
     continue-on-error: true
     steps:
     - uses: actions/checkout@v1
@@ -52,55 +37,27 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        build: [stable, beta]
-        include:
-          - build: stable
-            os: ubuntu-latest
-            rust: stable
-          - build: beta
-            os: ubuntu-latest
-            rust: beta
+    runs-on: ubuntu-latest
+    container: kisiodigital/rust-ci:latest-proj
     steps:
-    - name: Install proj
-      run: |
-        wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | sudo apt-key add -
-        echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" | sudo tee /etc/apt/sources.list.d/kisio-digital.list
-        sudo apt update
-        sudo apt install --yes libxml2-utils pkg-config libssl-dev clang libtiff-dev libcurl4-nss-dev proj=${PROJ_VERSION}
     - uses: actions/checkout@master
     - name: Checkout Submodules
       uses: textbook/git-checkout-submodule-action@2.1.1
-    - name: Install Rust ${{ matrix.rust }}
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
+    - name: Install xmllint
+      run: apt update && apt install --yes libxml2-utils
     - name: Run tests with and without features
       run: make test
 
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
+    container: kisiodigital/rust-ci:latest-proj
     steps:
-    - name: Install proj
-      run: |
-        wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | sudo apt-key add -
-        echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" | sudo tee /etc/apt/sources.list.d/kisio-digital.list
-        sudo apt update
-        sudo apt install --yes libxml2-utils pkg-config libssl-dev clang proj=${PROJ_VERSION}
     - uses: actions/checkout@master
     - name: Checkout Submodules
       uses: textbook/git-checkout-submodule-action@2.1.1
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          profile: minimal
-          override: true
+    - name: Install xmllint
+      run: apt update && apt install --yes libxml2-utils pkg-config libssl-dev
     - name: Install `cargo-tarpaulin`
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,27 +3,13 @@ on:
   release:
     types: [published]
 
-env:
-  PROJ_VERSION: 7.1.0
-
 jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    containers: kisiodigital/rust-ci:latest-proj
     steps:
-    - name: Install proj
-      run: |
-        wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | sudo apt-key add -
-        echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" | sudo tee /etc/apt/sources.list.d/kisio-digital.list
-        sudo apt update
-        sudo apt install --yes pkg-config libssl-dev clang libtiff-dev libcurl4-nss-dev proj=${PROJ_VERSION}
     - uses: actions/checkout@master
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: stable
-          profile: minimal
-          override: true
     - name: Cargo login
       uses: actions-rs/cargo@v1
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,54 @@
-ARG PROJ_VERSION="7.1.0"
+## Inspired by Docker image `kisiodigital/rust-ci:latest-proj` for `proj` installation
+## See https://github.com/CanalTP/ci-images/blob/master/rust/proj/Dockerfile
+ARG PROJ_VERSION="7.2.1"
+# For running `proj`, the following Debian packages are needed:
+# - 'clang' provides 'llvm-config', 'libclang.so' and 'stddef.h' needed for compiling 'proj-sys'
+# - 'libtiff5' provides 'libtiff.so', needed for linking when 'proj-sys' is used
+# - 'libcurl3-nss' provides 'libcurl-nss.so', needed for linking when 'proj-sys' is used
+# - 'proj' provides 'proj.h' and 'libproj.so', needed for compiling 'proj-sys' (installed manually below)
+ARG RUNTIME_DEPENDENCIES="clang libtiff5 libcurl3-nss"
 
-FROM rust:1-slim-stretch as builder
+FROM debian:stretch as proj-builder
 ARG PROJ_VERSION
-ENV PROJ_DEB "proj_${PROJ_VERSION}_amd64.deb"
-ENV GPG_KEY "C60D758F807A525534C5DFD57B639E3638A8112A"
-RUN apt update && apt install --yes apt-transport-https gnupg2 wget
-RUN wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | apt-key add -
-RUN echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" > /etc/apt/sources.list.d/kisio-digital.list
-RUN apt update && apt install --yes pkg-config libssl-dev clang libtiff-dev libcurl4-nss-dev proj=${PROJ_VERSION}
+ARG RUNTIME_DEPENDENCIES
+# For building `libproj' and the Rust's crate `proj-sys`, the following Debian packages are needed:
+ENV BUILD_DEPENDENCIES="libcurl4-nss-dev libsqlite3-dev libtiff5-dev cmake pkg-config sqlite3 wget"
+RUN apt update
+RUN apt install --yes ${BUILD_DEPENDENCIES} ${RUNTIME_DEPENDENCIES}
+RUN wget https://github.com/OSGeo/PROJ/releases/download/${PROJ_VERSION}/proj-${PROJ_VERSION}.tar.gz
+RUN tar -xzvf proj-${PROJ_VERSION}.tar.gz
+RUN mv proj-${PROJ_VERSION} /tmp/proj-src
+WORKDIR /tmp/proj-src
+RUN ./configure --prefix=/usr
+RUN make -j$(nproc)
+# copy all the installation files inside a temporary folder
+# so they are copyable from the following stages of the Docker image
+RUN make DESTDIR=/tmp/proj-build install
 
+FROM debian:stretch as rust-builder
+ARG RUNTIME_DEPENDENCIES
+RUN apt update
+RUN apt install --yes ${RUNTIME_DEPENDENCIES}
+# install 'proj'
+# we copy all the files to the root ('/tmp/proj-build' contains a 'usr/' folder)
+COPY --from=proj-builder /tmp/proj-build /
 WORKDIR /usr/src/app
 COPY . ./
-RUN cargo build --workspace --release \
-	&& mkdir /usr/src/bin && for file in ls ./target/release/*; do if test -f $file -a -x $file; then cp $file /usr/src/bin; fi; done \
-	&& cd .. && rm -rf app
+# install rustup
+RUN apt install --yes curl
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH "/root/.cargo/bin:$PATH"
+# build the project
+RUN cargo build --workspace --release
+RUN mkdir /usr/src/bin && for file in ls ./target/release/*; do if test -f $file -a -x $file; then cp $file /usr/src/bin; fi; done 
 
 FROM debian:stretch-slim
-ARG PROJ_VERSION
-ENV PROJ_DEB "proj_${PROJ_VERSION}_amd64.deb"
-ENV GPG_KEY "C60D758F807A525534C5DFD57B639E3638A8112A"
-VOLUME /app/input
-VOLUME /app/output
-RUN BUILD_DEPENDENCIES="apt-transport-https gnupg2 wget" \
-	&& apt update \
-	&& apt install --yes ${BUILD_DEPENDENCIES} \
-	&& wget --quiet --output-document - "https://kisiodigital.jfrog.io/kisiodigital/api/gpg/key/public" | apt-key add - \
-	&& echo "deb [arch=amd64] https://kisiodigital.jfrog.io/kisiodigital/debian-local stretch main" > /etc/apt/sources.list.d/kisio-digital.list \
-	&& apt update \
-	&& apt install --yes libtiff-dev libcurl4-nss-dev proj=${PROJ_VERSION} \
-	&& apt purge --yes ${BUILD_DEPENDENCIES} \
-	&& apt autoremove --yes \
-	&& rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/src/bin/* /usr/local/bin/
+ARG RUNTIME_DEPENDENCIES
+# install 'proj'
+# We copy all the files to the root ('/tmp/proj-build' contains a 'usr/' folder)
+COPY --from=proj-builder /tmp/proj-build /
+RUN apt update \
+    && apt install --yes ${RUNTIME_DEPENDENCIES} \
+    && apt autoremove --yes \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=rust-builder /usr/src/bin/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJ_VERSION = 7.1.0
+PROJ_VERSION = 7.2.1
 install_proj: ## Install PROJ and clang (requirements to use proj crate)
 	sudo apt update
 	sudo apt install -y clang

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ So it must be installed on the system to compile and use those crates.
 ### [PROJ] for binaries
 
 Using the [`proj` crate] requires some system-dependencies installation.\
-The version `7.1.0` of [PROJ] is needed (used and tested by maintainers).
+The version `7.2.1` of [PROJ] is needed (used and tested by maintainers).
 
 To help the installation you can execute the following command (On Debian systems):
 

--- a/src/netex_france/exporter.rs
+++ b/src/netex_france/exporter.rs
@@ -171,8 +171,8 @@ impl<'a> Exporter<'a> {
     }
 
     pub(in crate::netex_france) fn get_coordinates_converter() -> Result<Proj> {
-        let from = "EPSG:4326";
-        let to = "EPSG:2154";
+        let from = "+proj=longlat +datum=WGS84 +no_defs"; // https://epsg.io/4326
+        let to = "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"; // https://epsg.io/2154
         Proj::new_known_crs(from, to, None)
             .ok_or_else(|| format_err!("Proj cannot build a converter from '{}' to '{}'", from, to))
     }

--- a/src/netex_france/exporter.rs
+++ b/src/netex_france/exporter.rs
@@ -171,8 +171,7 @@ impl<'a> Exporter<'a> {
     }
 
     pub(in crate::netex_france) fn get_coordinates_converter() -> Result<Proj> {
-        // FIXME: String 'EPSG:4326' is failing at runtime (string below is equivalent but works)
-        let from = "+proj=longlat +datum=WGS84 +no_defs"; // See https://epsg.io/4326
+        let from = "EPSG:4326";
         let to = "EPSG:2154";
         Proj::new_known_crs(from, to, None)
             .ok_or_else(|| format_err!("Proj cannot build a converter from '{}' to '{}'", from, to))


### PR DESCRIPTION
Use now the custom image that already contains `rustfmt`, `clippy`,`cargo-audit` and `libproj`. This should improve the build time and make it more reliable with `libproj` since we're not depending anymore on the custom `.deb`.

- [x] release `kisiodigital/rust-ci` (see https://github.com/CanalTP/ci-images/pull/17)