### PR TITLE
[tech] do not upgrade to minidom:0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ iso4217 = "0.3"
 lazy_static = "1"
 log = "0.4"
 md5 = "0.7"
+# do not upgrade to 'minidom:0.13.0' (too strict on namespaces and no XML comment support)
+# https://github.com/CanalTP/transit_model/pull/746
 minidom = "0.12"
 minidom_ext = "1"
 minidom_writer = "1"


### PR DESCRIPTION
Just some documentation to keep track of why we ought to not upgrade to `minidom:0.13.0`.