### PR TITLE
[ci] report 'audit' errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,13 @@ jobs:
     name: Audits
     runs-on: ubuntu-latest
     container: kisiodigital/rust-ci:latest-proj
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v1
     - name: Security audit
-      uses: actions-rs/audit-check@v1
+      uses: actions-rs/audit-check@v1.2.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
 
   tests:
     name: Tests


### PR DESCRIPTION
`cargo audit` is currently deactivated. Which means we're completely blind to any vulnerability. However, if we turn it on, then it means we're going to have our CI breaking... without solution to fix it sometimes.

An ideal middle ground would be that `cargo audit` makes somewhat the build orange (with warnings) but it seems that Github Actions is very binary, it's either a success or a failure.

This PR proposes that Github Actions, at least, report a comment in the current PR when `cargo-audit` reports any error.