### PR TITLE
add a precise git_version to transit-model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ typed_index_collection = "1"
 walkdir = "2"
 wkt = "0.8"
 zip = { version = "0.5", default-features = false, features = ["deflate"] }
+git-version = "0.3"
 
 [[test]]
 name = "write_netex_france"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -23,3 +23,4 @@ slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
 transit_model = { version = "0.34", path = "../", features = ["proj"] }
+lazy_static = "1"

--- a/gtfs2netexfr/src/main.rs
+++ b/gtfs2netexfr/src/main.rs
@@ -24,7 +24,7 @@ use structopt::StructOpt;
 use transit_model::{read_utils, Result};
 
 lazy_static::lazy_static! {
-    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+    pub static ref GIT_VERSION: String = transit_model::binary_full_version(env!("CARGO_PKG_VERSION"));
 }
 
 fn get_version() -> &'static str {

--- a/gtfs2netexfr/src/main.rs
+++ b/gtfs2netexfr/src/main.rs
@@ -23,8 +23,10 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::{read_utils, Result};
 
+const GIT_VERSION: &str = transit_model::git_version();
+
 #[derive(Debug, StructOpt)]
-#[structopt(name = "gtfs2netexfr", about = "Convert a GTFS to NeTEx France.")]
+#[structopt(name = "gtfs2netexfr", about = "Convert a GTFS to NeTEx France.", version = GIT_VERSION)]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/gtfs2netexfr/src/main.rs
+++ b/gtfs2netexfr/src/main.rs
@@ -23,10 +23,16 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::{read_utils, Result};
 
-const GIT_VERSION: &str = transit_model::git_version();
+lazy_static::lazy_static! {
+    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+}
+
+fn get_version() -> &'static str {
+    &GIT_VERSION
+}
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "gtfs2netexfr", about = "Convert a GTFS to NeTEx France.", version = GIT_VERSION)]
+#[structopt(name = "gtfs2netexfr", about = "Convert a GTFS to NeTEx France.", version = get_version())]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -23,3 +23,4 @@ slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
 transit_model = { version = "0.34", path = "../" }
+lazy_static = "1"

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -23,10 +23,16 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::{read_utils, transfers::generates_transfers, PrefixConfiguration, Result};
 
-const GIT_VERSION: &str = transit_model::git_version();
+lazy_static::lazy_static! {
+    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+}
+
+fn get_version() -> &'static str {
+    &GIT_VERSION
+}
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "gtfs2ntfs", about = "Convert a GTFS to an NTFS.", version = GIT_VERSION)]
+#[structopt(name = "gtfs2ntfs", about = "Convert a GTFS to an NTFS.", version = get_version())]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -24,7 +24,7 @@ use structopt::StructOpt;
 use transit_model::{read_utils, transfers::generates_transfers, PrefixConfiguration, Result};
 
 lazy_static::lazy_static! {
-    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+    pub static ref GIT_VERSION: String = transit_model::binary_full_version(env!("CARGO_PKG_VERSION"));
 }
 
 fn get_version() -> &'static str {

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -23,8 +23,10 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::{read_utils, transfers::generates_transfers, PrefixConfiguration, Result};
 
+const GIT_VERSION: &str = transit_model::git_version();
+
 #[derive(Debug, StructOpt)]
-#[structopt(name = "gtfs2ntfs", about = "Convert a GTFS to an NTFS.")]
+#[structopt(name = "gtfs2ntfs", about = "Convert a GTFS to an NTFS.", version = GIT_VERSION)]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -23,3 +23,4 @@ slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
 transit_model = { version = "0.34", path = "../" }
+lazy_static = "1"

--- a/ntfs2gtfs/src/main.rs
+++ b/ntfs2gtfs/src/main.rs
@@ -23,7 +23,7 @@ use structopt::StructOpt;
 use transit_model::Result;
 
 lazy_static::lazy_static! {
-    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+    pub static ref GIT_VERSION: String = transit_model::binary_full_version(env!("CARGO_PKG_VERSION"));
 }
 
 fn get_version() -> &'static str {

--- a/ntfs2gtfs/src/main.rs
+++ b/ntfs2gtfs/src/main.rs
@@ -22,10 +22,16 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::Result;
 
-const GIT_VERSION: &str = transit_model::git_version();
+lazy_static::lazy_static! {
+    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+}
+
+fn get_version() -> &'static str {
+    &GIT_VERSION
+}
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "ntfs2gtfs", about = "Convert an NTFS to a GTFS.", version = GIT_VERSION)]
+#[structopt(name = "ntfs2gtfs", about = "Convert an NTFS to a GTFS.", version = get_version())]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/ntfs2gtfs/src/main.rs
+++ b/ntfs2gtfs/src/main.rs
@@ -22,8 +22,10 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::Result;
 
+const GIT_VERSION: &str = transit_model::git_version();
+
 #[derive(Debug, StructOpt)]
-#[structopt(name = "ntfs2gtfs", about = "Convert an NTFS to a GTFS.")]
+#[structopt(name = "ntfs2gtfs", about = "Convert an NTFS to a GTFS.", version = GIT_VERSION)]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -23,3 +23,4 @@ slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
 transit_model = { version = "0.34", path = "../", features = ["proj"] }
+lazy_static = "1"

--- a/ntfs2netexfr/src/main.rs
+++ b/ntfs2netexfr/src/main.rs
@@ -23,7 +23,7 @@ use structopt::StructOpt;
 use transit_model::Result;
 
 lazy_static::lazy_static! {
-    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+    pub static ref GIT_VERSION: String = transit_model::binary_full_version(env!("CARGO_PKG_VERSION"));
 }
 
 fn get_version() -> &'static str {

--- a/ntfs2netexfr/src/main.rs
+++ b/ntfs2netexfr/src/main.rs
@@ -22,8 +22,10 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::Result;
 
+const GIT_VERSION: &str = transit_model::git_version();
+
 #[derive(Debug, StructOpt)]
-#[structopt(name = "ntfs2netexfr", about = "Convert a NTFS to NeTEx France.")]
+#[structopt(name = "ntfs2netexfr", about = "Convert a NTFS to NeTEx France.", version = GIT_VERSION)]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/ntfs2netexfr/src/main.rs
+++ b/ntfs2netexfr/src/main.rs
@@ -22,10 +22,16 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::Result;
 
-const GIT_VERSION: &str = transit_model::git_version();
+lazy_static::lazy_static! {
+    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+}
+
+fn get_version() -> &'static str {
+    &GIT_VERSION
+}
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "ntfs2netexfr", about = "Convert a NTFS to NeTEx France.", version = GIT_VERSION)]
+#[structopt(name = "ntfs2netexfr", about = "Convert a NTFS to NeTEx France.", version = get_version())]
 struct Opt {
     /// Input directory.
     #[structopt(short, long, parse(from_os_str), default_value = ".")]

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -23,3 +23,4 @@ slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
 transit_model = { version = "0.34", path = "../" }
+lazy_static = "1"

--- a/ntfs2ntfs/src/main.rs
+++ b/ntfs2ntfs/src/main.rs
@@ -22,8 +22,10 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::{transfers::generates_transfers, Result};
 
+const GIT_VERSION: &str = transit_model::git_version();
+
 #[derive(Debug, StructOpt)]
-#[structopt(name = "ntfs2ntfs", about = "Convert an NTFS to an NTFS.")]
+#[structopt(name = "ntfs2ntfs", about = "Convert an NTFS to an NTFS.", version = GIT_VERSION)]
 struct Opt {
     /// Input directory.
     #[structopt(short = "i", long = "input", parse(from_os_str), default_value = ".")]

--- a/ntfs2ntfs/src/main.rs
+++ b/ntfs2ntfs/src/main.rs
@@ -23,7 +23,7 @@ use structopt::StructOpt;
 use transit_model::{transfers::generates_transfers, Result};
 
 lazy_static::lazy_static! {
-    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+    pub static ref GIT_VERSION: String = transit_model::binary_full_version(env!("CARGO_PKG_VERSION"));
 }
 
 fn get_version() -> &'static str {

--- a/ntfs2ntfs/src/main.rs
+++ b/ntfs2ntfs/src/main.rs
@@ -22,10 +22,16 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 use transit_model::{transfers::generates_transfers, Result};
 
-const GIT_VERSION: &str = transit_model::git_version();
+lazy_static::lazy_static! {
+    pub static ref GIT_VERSION: String = format!("{version} (transit_model = {lib_version})", version=env!("CARGO_PKG_VERSION"), lib_version=transit_model::GIT_VERSION);
+}
+
+fn get_version() -> &'static str {
+    &GIT_VERSION
+}
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "ntfs2ntfs", about = "Convert an NTFS to an NTFS.", version = GIT_VERSION)]
+#[structopt(name = "ntfs2ntfs", about = "Convert an NTFS to an NTFS.", version = get_version())]
 struct Opt {
     /// Input directory.
     #[structopt(short = "i", long = "input", parse(from_os_str), default_value = ".")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,4 +84,4 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub use crate::model::Model;
 
-pub use crate::version_utils::GIT_VERSION;
+pub use crate::version_utils::{binary_full_version, GIT_VERSION};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod read_utils;
 pub mod test_utils;
 pub mod transfers;
 pub mod validity_period;
+mod version_utils;
 pub mod vptranslator;
 
 /// Current version of the NTFS format
@@ -82,3 +83,5 @@ pub type Error = failure::Error;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub use crate::model::Model;
+
+pub use crate::version_utils::git_version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,4 +84,4 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub use crate::model::Model;
 
-pub use crate::version_utils::git_version;
+pub use crate::version_utils::GIT_VERSION;

--- a/src/version_utils.rs
+++ b/src/version_utils.rs
@@ -14,4 +14,5 @@
 //! Some utility to get the transit_model version
 
 /// Precise git version of transit_model
-pub const GIT_VERSION: &str = git_version::git_version!(args = ["--tags", "--dirty=-modified"]);
+pub const GIT_VERSION: &str =
+    git_version::git_version!(args = ["--tags", "--dirty=-modified"], fallback = "unknown");

--- a/src/version_utils.rs
+++ b/src/version_utils.rs
@@ -14,5 +14,12 @@
 //! Some utility to get the transit_model version
 
 /// Precise git version of transit_model
+/// the version will be:
+/// v{last github tag}-{commit number}-{commit hash}{"-modified" if some changes have been done since last commit}
 pub const GIT_VERSION: &str =
     git_version::git_version!(args = ["--tags", "--dirty=-modified"], fallback = "unknown");
+
+/// get the binary version and the transit_model version
+pub fn binary_full_version(binary_version: &str) -> String {
+    format!("{} (transit_model = {})", binary_version, GIT_VERSION)
+}

--- a/src/version_utils.rs
+++ b/src/version_utils.rs
@@ -14,5 +14,4 @@
 //! Some utility to get the transit_model version
 
 /// Precise git version of transit_model
-pub const GIT_VERSION: &'static str =
-    git_version::git_version!(args = ["--tags", "--dirty=-modified"]);
+pub const GIT_VERSION: &str = git_version::git_version!(args = ["--tags", "--dirty=-modified"]);

--- a/src/version_utils.rs
+++ b/src/version_utils.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2017 Kisio Digital and/or its affiliates.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License as published by the
+// Free Software Foundation, version 3.
+
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+// details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>
+//! Some utility to get the transit_model version
+
+/// get the precise git version of transit_model
+pub const fn git_version() -> &'static str {
+    git_version::git_version!(args = ["--tags", "--dirty=-modified"])
+}

--- a/src/version_utils.rs
+++ b/src/version_utils.rs
@@ -13,7 +13,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>
 //! Some utility to get the transit_model version
 
-/// get the precise git version of transit_model
-pub const fn git_version() -> &'static str {
-    git_version::git_version!(args = ["--tags", "--dirty=-modified"])
-}
+/// Precise git version of transit_model
+pub const GIT_VERSION: &'static str =
+    git_version::git_version!(args = ["--tags", "--dirty=-modified"]);


### PR DESCRIPTION
usefull for workflows depending directly of the git repository

seems to handle well the incremental compilation:
```sh
❯ cargo build --all
   Compiling transit_model v0.34.0 (/home/antoine/dev/kisio/transit_model)
   Compiling ntfs2gtfs v1.1.0 (/home/antoine/dev/kisio/transit_model/ntfs2gtfs)
   Compiling transit_model_builder v0.3.0 (/home/antoine/dev/kisio/transit_model/model-builder)
   Compiling restrict-validity-period v1.0.0 (/home/antoine/dev/kisio/transit_model/restrict-validity-period)
   Compiling gtfs2ntfs v1.1.0 (/home/antoine/dev/kisio/transit_model/gtfs2ntfs)
   Compiling gtfs2netexfr v1.1.0 (/home/antoine/dev/kisio/transit_model/gtfs2netexfr)
   Compiling ntfs2ntfs v1.0.0 (/home/antoine/dev/kisio/transit_model/ntfs2ntfs)
   Compiling ntfs2netexfr v1.0.0 (/home/antoine/dev/kisio/transit_model/ntfs2netexfr)
    Finished dev [unoptimized + debuginfo] target(s) in 15.30s

❯ cargo build --all
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
```

```sh
❯ cargo build --all && ./target/debug/gtfs2ntfs --version
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
gtfs2ntfs v0.34.0-3-g3f518f2-modified
```

:warning: `do_not_merge` is there because we want to use that PR to test our CI (internal webhooks), let's wait until 2021/03/25 max on that :pray: 