### PR TITLE
[feature] automatically create output folders when not existing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.34.1"
+version = "0.35.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.34", path = "../", features = ["proj"] }
+transit_model = { version = "0.35", path = "../", features = ["proj"] }
 lazy_static = "1"

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.34", path = "../" }
+transit_model = { version = "0.35", path = "../" }
 lazy_static = "1"

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.34", path = "../" }
+transit_model = { version = "0.35", path = "../" }
 lazy_static = "1"

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.34", path = "../", features = ["proj"] }
+transit_model = { version = "0.35", path = "../", features = ["proj"] }
 lazy_static = "1"

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.34", path = "../" }
+transit_model = { version = "0.35", path = "../" }
 lazy_static = "1"

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -21,4 +21,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.34", path = "../" }
+transit_model = { version = "0.35", path = "../" }

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -452,6 +452,7 @@ pub fn write<P: AsRef<Path>>(model: Model, path: P) -> Result<()> {
     let collections = remove_stop_zones(model);
     let model = Model::new(collections)?;
     let path = path.as_ref();
+    std::fs::create_dir_all(path)?;
     info!("Writing GTFS to {:?}", path);
 
     write::write_transfers(path, &model.transfers)?;

--- a/src/netex_france/exporter.rs
+++ b/src/netex_france/exporter.rs
@@ -153,6 +153,7 @@ impl<'a> Exporter<'a> {
     where
         P: AsRef<Path>,
     {
+        std::fs::create_dir_all(&path)?;
         self.write_lines(&path)?;
         self.write_stops(&path)?;
         self.write_calendars(&path)?;

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -232,6 +232,7 @@ pub fn write<P: AsRef<path::Path>>(
     current_datetime: DateTime<FixedOffset>,
 ) -> Result<()> {
     let path = path.as_ref();
+    std::fs::create_dir_all(path)?;
     info!("Writing NTFS to {:?}", path);
 
     write::write_feed_infos(path, &model, current_datetime)?;


### PR DESCRIPTION
Long time standing issue that was creating cryptic error when trying to **write** a NTFS (and also a NeTEx France).

```
Error reading "/mnt/out/output_dir/feed_infos.txt"
No such file or directory (os error 2)
```