### PR TITLE
[feature] add 'Model::add_calendar' under 'mutable-model' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ members = [
 
 [features]
 xmllint = ["proj"]
+# Experimental feature, use at your own risks
+mutable-model = []
 
 [dependencies]
 chrono = "0.4"

--- a/model-builder/src/lib.rs
+++ b/model-builder/src/lib.rs
@@ -17,3 +17,4 @@ use transit_model::{model, objects};
 mod builder;
 
 pub use crate::builder::ModelBuilder;
+pub use transit_model::objects::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,11 @@
 //! this case, take a look at the [`CONTRIBUTING.md`] for more information on
 //! this feature.
 //!
+//! ## `mutable-model`
+//! This is an experimental feature that allows you to get some abilities to
+//! mutate a `Model`. It might not be completely stable at the moment so use
+//! with care (or not at all!).
+//!
 //! [`CONTRIBUTING.md`]: https://github.com/CanalTP/transit_model/blob/master/CONTRIBUTING.md
 
 #![deny(missing_docs)]


### PR DESCRIPTION
Introduce a new function to mutate the model.

```rust
Model::add_calendar(
  &mut self,
  calendar: Calendar,
  // Other parameters ?
)
```