### PR TITLE
[CI] Limit branch-build to 'master'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: Continuous Integration
-on: [push, pull_request]
+
+on:
+    push:
+        branches:  # Build 'master' branch
+            - 'master'
+    pull_request:  # Build any PR
 
 jobs:
   rustfmt:


### PR DESCRIPTION
To avoid double-builds on PR (branch+PR)
Inspired by Kirin, but letting build on tags be launched (even though it's publish part that matters more, tests are nice to have)