### PR TITLE
[tech] Bump to 0.36.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.35.0"
+version = "0.36.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.35", path = "../", features = ["proj"] }
+transit_model = { version = "0.36", path = "../", features = ["proj"] }
 lazy_static = "1"

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.35", path = "../" }
+transit_model = { version = "0.36", path = "../" }
 lazy_static = "1"

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.35", path = "../" }
+transit_model = { version = "0.36", path = "../" }
 lazy_static = "1"

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.35", path = "../", features = ["proj"] }
+transit_model = { version = "0.36", path = "../", features = ["proj"] }
 lazy_static = "1"

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.35", path = "../" }
+transit_model = { version = "0.36", path = "../" }
 lazy_static = "1"

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -21,4 +21,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.35", path = "../" }
+transit_model = { version = "0.36", path = "../" }


### PR DESCRIPTION
Bump to 0.36.0 for next release (and especially https://github.com/CanalTP/transit_model/pull/773)