### PR TITLE
[feature] remove the versions (crates are unpublished)

### DIFF
--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.36", path = "../", features = ["proj"] }
+transit_model = { path = "../", features = ["proj"] }
 lazy_static = "1"

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.36", path = "../" }
+transit_model = { path = "../" }
 lazy_static = "1"

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.36", path = "../" }
+transit_model = { path = "../" }
 lazy_static = "1"

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.36", path = "../", features = ["proj"] }
+transit_model = { path = "../", features = ["proj"] }
 lazy_static = "1"

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -22,5 +22,5 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.36", path = "../" }
+transit_model = { path = "../" }
 lazy_static = "1"

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -21,4 +21,4 @@ slog-scope = "4.1"
 slog-stdlog = "4.0"
 slog-term = "2.4"
 structopt = "0.3"
-transit_model = { version = "0.36", path = "../" }
+transit_model = { path = "../" }


### PR DESCRIPTION
Having both `path` and `version` is useful only when the _crate_ is published. From the [documentation](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies), `path` is always used, except for `publish` where `version is used. Since we don't release these crates, versions are not needed.

NOTE: we also want to avoid a situation where we would publish a crate `gtfs2ntfs:0.36.1` with a dependency `transit_model:0.36.0` which would be possible with a dependency specified like `version = "0.36"`. Therefore, the rational here is that since we don't publish these crates at all, removing the version is a way to push back the problem to the day we will decide to do it (or not !).