### PR TITLE
[fix] 'install_proj' in the Makefile now works as expected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-PROJ_VERSION = 7.2.1 # Version required by `proj` crate used in cargo.toml
+# Version required by `proj` crate used in cargo.toml
+PROJ_VERSION = 7.2.1
 
 install_proj_deps: ## Install dependencies the proj crate needs in order to build libproj from source
 	sudo apt update


### PR DESCRIPTION
Putting a comment at the end of the line makes the space after the version, part of the variable... which obviously breaks the URL afterwards (trying to download to `https://github.com/OSGeo/proj.4/releases/download/7.2.1 /proj-7.2.1 .tar.gz`). `make` is awesome!