### PR TITLE
[ci] 'cargo-tarpaulin:v0.18.0' does not accept '--all-targets' anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: install
-        args: cargo-tarpaulin
+        args: cargo-tarpaulin --version 0.16.0
     - name: Run tests for coverage
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
There was a change of version of `cargo-tarpaulin` on the 28th of June. The new version doesn't accept `--all-targets` anymore so our CI fails. This PR should fix it.