### PR TITLE
[feature] convert 'gtfs2ntfs' to tracing

### DIFF
--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -15,12 +15,9 @@ keywords = ["gtfs", "ntfs", "transit"]
 chrono = "0.4"
 failure = "0.1"
 log = "0.4"
-slog = "2.5"
-slog-async = "2.3"
-slog-envlogger = "2.1"
-slog-scope = "4.1"
-slog-stdlog = "4.0"
-slog-term = "2.4"
 structopt = "0.3"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.2"
 transit_model = { path = "../" }
 lazy_static = "1"

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, FixedOffset};
 use log::info;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _};
 use transit_model::{read_utils, transfers::generates_transfers, PrefixConfiguration, Result};
 
 lazy_static::lazy_static! {
@@ -93,8 +94,6 @@ struct Opt {
 }
 
 fn run(opt: Opt) -> Result<()> {
-    tracing_subscriber::fmt::init();
-
     info!("Launching gtfs2ntfs...");
 
     let (contributor, dataset, feed_infos) = read_utils::read_config(opt.config)?;
@@ -130,6 +129,10 @@ fn run(opt: Opt) -> Result<()> {
 }
 
 fn main() {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::filter::EnvFilter::from_default_env())
+        .init();
     if let Err(err) = run(Opt::from_args()) {
         for cause in err.iter_chain() {
             eprintln!("{}", cause);


### PR DESCRIPTION
I'm opening this as a Draft for discussion. I really think we should convert all of `transit_model` (library and binaries) to `tracing` as it gives us some more capabilities without losing the support for `log`.

Let me know if you're OK that I continue converting the rest of `transit_model`. Probably can be done in multiple PR.