### PR TITLE
[feature] default logs to INFO (was NONE)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.39.0"
+version = "0.40.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"


### PR DESCRIPTION
When `slog` was removed in #791, we lost the default level of logging: previous versions was defaulting to INFO, but `tracing` was logging nothing. This should bring back a default logging level at INFO.

Since the code for initializing the logger was a bit longer, I put all of it in a `init_logger()` function.