### PR TITLE
[feature] use 'thiserror' for the existing errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.39.0"
+version = "0.40.0"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -404,33 +404,14 @@ impl std::fmt::Display for Rgb {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum RgbError {
+    #[error("String is not a valid Hexadecimal value")]
     NotHexa,
+    #[error("String is too long (6 characters expected)")]
     TooLongHexa,
+    #[error("String is too short (6 characters expected)")]
     TooShortHexa,
-}
-
-use std::error::Error;
-
-impl std::fmt::Display for RgbError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            RgbError::NotHexa => f.write_str("RgbError_NotHexa"),
-            RgbError::TooLongHexa => f.write_str("RgbError_TooLongHexa"),
-            RgbError::TooShortHexa => f.write_str("RgbError_NumberOfChar"),
-        }
-    }
-}
-
-impl Error for RgbError {
-    fn description(&self) -> &str {
-        match *self {
-            RgbError::NotHexa => "String is not a valid Hexadecimal value",
-            RgbError::TooLongHexa => "String is too long (6 characters expected)",
-            RgbError::TooShortHexa => "String is too short (6 characters expected)",
-        }
-    }
 }
 
 impl FromStr for Rgb {
@@ -761,30 +742,16 @@ impl AddPrefix for Frequency {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TimeError {
+    #[error("Time format should be HH:MM:SS")]
     WrongFormat,
+    #[error("Minutes and Seconds should be in [0..59] range")]
     WrongValue,
 }
 impl From<std::num::ParseIntError> for TimeError {
     fn from(_error: std::num::ParseIntError) -> Self {
         TimeError::WrongFormat
-    }
-}
-impl std::fmt::Display for TimeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            TimeError::WrongFormat => f.write_str("wrong format"),
-            TimeError::WrongValue => f.write_str("wrong value"),
-        }
-    }
-}
-impl Error for TimeError {
-    fn description(&self) -> &str {
-        match *self {
-            TimeError::WrongFormat => "Time format should be HH:MM:SS",
-            TimeError::WrongValue => "Minutes and Seconds should be in [0..59] range",
-        }
     }
 }
 


### PR DESCRIPTION
Using `thiserror` (already in our dependencies) to improve the definition of 2 existing errors (`RgbError` and `TimeError`). Note that they both were implementing [`description()` which is a deprecated function of the trait `std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html#method.description). The modification is not strictly equivalent to what was existing before (because there is now no difference between the `Display` implementation and the associated error message). But I believe this is fine since `description()` should be implemented into `Display`.