### PR TITLE
[feature] use 'skip_error:2.0.0' with 'tracing'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,10 @@ relational_types = "2"
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-skip_error = { version = "1.1", features = ["log"] }
+skip_error = { git = "https://github.com/CanalTP/skip_error.git", branch = "tracing", version = "2.0", features = ["tracing"] }
 tempfile = "3"
 thiserror = "1"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 typed_index_collection = "2"
 walkdir = "2"
 wkt = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ relational_types = "2"
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-skip_error = { git = "https://github.com/CanalTP/skip_error.git", branch = "tracing", version = "2.0", features = ["tracing"] }
+skip_error = { version = "2.0", features = ["tracing"] }
 tempfile = "3"
 thiserror = "1"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }

--- a/src/calendars.rs
+++ b/src/calendars.rs
@@ -26,7 +26,7 @@ use crate::vptranslator::translate;
 use crate::Result;
 use chrono::{self, Datelike, Weekday};
 use failure::{bail, format_err, ResultExt};
-use log::{info, Level as LogLevel};
+use log::info;
 use serde::{Deserialize, Serialize};
 use skip_error::skip_error_and_log;
 use std::collections::BTreeSet;
@@ -182,7 +182,7 @@ where
                     id: calendar.id.clone(),
                     dates,
                 }),
-                LogLevel::Warn
+                tracing::Level::WARN
             );
         }
     }
@@ -209,7 +209,7 @@ pub fn write_calendar_dates(
                     "Validity period not found for service id {}",
                     c.id.clone()
                 )),
-                LogLevel::Warn
+                tracing::Level::WARN
             );
             translations.push(Calendar {
                 id: c.id.clone(),

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -30,7 +30,7 @@ use crate::{
 use derivative::Derivative;
 use failure::{bail, format_err, Error};
 use geo::{LineString, Point};
-use log::{info, warn, Level as LogLevel};
+use log::{info, warn};
 use serde::Deserialize;
 use skip_error::{skip_error_and_log, SkipError};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -736,8 +736,10 @@ where
         let equipment_id = get_equipment_id_and_populate_equipments(equipments, &stop);
         match stop.location_type {
             StopLocationType::StopPoint => {
-                let mut stop_point =
-                    skip_error_and_log!(objects::StopPoint::try_from(stop.clone()), LogLevel::Warn);
+                let mut stop_point = skip_error_and_log!(
+                    objects::StopPoint::try_from(stop.clone()),
+                    tracing::Level::WARN
+                );
                 if stop.parent_station.is_none() {
                     let stop_area = objects::StopArea::from(stop_point.clone());
                     stop_point.stop_area_id = stop_area.id.clone();
@@ -749,14 +751,16 @@ where
             }
             StopLocationType::StopArea => {
                 let mut stop_area =
-                    skip_error_and_log!(objects::StopArea::try_from(stop), LogLevel::Warn);
+                    skip_error_and_log!(objects::StopArea::try_from(stop), tracing::Level::WARN);
                 stop_area.comment_links = comment_links;
                 stop_area.equipment_id = equipment_id;
                 stop_areas.push(stop_area);
             }
             _ => {
-                let mut stop_location =
-                    skip_error_and_log!(objects::StopLocation::try_from(stop), LogLevel::Warn);
+                let mut stop_location = skip_error_and_log!(
+                    objects::StopLocation::try_from(stop),
+                    tracing::Level::WARN
+                );
                 stop_location.comment_links = comment_links;
                 stop_location.equipment_id = equipment_id;
                 stop_locations.push(stop_location);
@@ -797,7 +801,7 @@ where
                         pathway.from_stop_id
                     )
                 }),
-            LogLevel::Warn
+            tracing::Level::WARN
         );
 
         pathway.to_stop_type = skip_error_and_log!(
@@ -816,7 +820,7 @@ where
                         pathway.to_stop_id
                     )
                 }),
-            LogLevel::Warn
+            tracing::Level::WARN
         );
         pathways.push(pathway);
     }
@@ -859,11 +863,11 @@ where
         };
         let from_stop_points = skip_error_and_log!(
             expand_stop_area(transfer.from_stop_id.as_str()),
-            LogLevel::Warn
+            tracing::Level::WARN
         );
         let to_stop_points = skip_error_and_log!(
             expand_stop_area(transfer.to_stop_id.as_str()),
-            LogLevel::Warn
+            tracing::Level::WARN
         );
         for from_stop_point in &from_stop_points {
             let approx = from_stop_point.coord.approx();
@@ -1106,7 +1110,7 @@ fn make_ntfs_vehicle_journeys(
         trips
             .iter()
             .map(|t| t.to_ntfs_vehicle_journey(routes, dataset, &property_id, networks))
-            .skip_error_and_log(LogLevel::Warn)
+            .skip_error_and_log(tracing::Level::WARN)
             .for_each(|vj| vehicle_journeys.push(vj));
     }
 
@@ -1217,7 +1221,7 @@ where
                     "frequency mapped to an unexisting trip {:?}",
                     frequency.trip_id
                 )),
-            LogLevel::Warn
+            tracing::Level::WARN
         );
         let mut start_time = frequency.start_time;
         let mut arrival_time_delta = match corresponding_vj.stop_times.iter().min() {
@@ -1445,7 +1449,7 @@ mod tests {
                     captured_logs[1].body,
                     "different agency timezone: Europe/London (id_1) - Europe/Paris (id_2)"
                 );
-                assert_eq!(captured_logs[1].level, LogLevel::Warn);
+                assert_eq!(captured_logs[1].level, log::Level::Warn);
             });
         });
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,7 +20,7 @@ use derivative::Derivative;
 use failure::{bail, format_err};
 use geo::algorithm::centroid::Centroid;
 use geo::MultiPoint;
-use log::{debug, warn, Level as LogLevel};
+use log::{debug, warn};
 use relational_types::{GetCorresponding, IdxSet, ManyToMany, OneToMany, Relation};
 use serde::{Deserialize, Serialize};
 use skip_error::skip_error_and_log;
@@ -625,7 +625,7 @@ impl Collections {
                                     &mut opening_timetable,
                                     &mut closing_timetable,
                                 ),
-                                LogLevel::Warn
+                                tracing::Level::WARN
                             );
                         }
                     }
@@ -1110,7 +1110,7 @@ impl Collections {
             if no_route_name || no_destination_id {
                 let (origin, destination) = skip_error_and_log!(
                     find_best_origin_destination(route_idx, &self, routes_to_vehicle_journeys,),
-                    LogLevel::Warn
+                    tracing::Level::WARN
                 );
                 if no_route_name
                     && !origin.name.trim().is_empty()

--- a/src/read_utils.rs
+++ b/src/read_utils.rs
@@ -18,7 +18,7 @@ use crate::{
     Result,
 };
 use failure::{bail, format_err, ResultExt};
-use log::{info, Level as LogLevel};
+use log::info;
 use serde::Deserialize;
 use skip_error::SkipError;
 use std::path;
@@ -271,7 +271,7 @@ where
             let objects = rdr
                 .deserialize()
                 .map(|object| object.with_context(|_| format!("Error reading {:?}", path)))
-                .skip_error_and_log(LogLevel::Warn)
+                .skip_error_and_log(tracing::Level::WARN)
                 .collect();
             Ok(objects)
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use chrono::NaiveDate;
 use failure::ResultExt;
-use log::{debug, error, info, Level as LogLevel};
+use log::{debug, error, info};
 use rust_decimal::Decimal;
 use skip_error::skip_error_and_log;
 use std::fs;
@@ -307,7 +307,7 @@ where
 {
     let mut collection = CollectionWithId::<T>::default();
     for object in read_objects::<_, T>(file_handler, file, false)? {
-        skip_error_and_log!(collection.push(object), LogLevel::Warn);
+        skip_error_and_log!(collection.push(object), tracing::Level::WARN);
     }
     Ok(collection)
 }
@@ -322,7 +322,7 @@ where
 {
     let mut collection = CollectionWithId::<T>::default();
     for object in read_objects::<_, T>(file_handler, file, true)? {
-        skip_error_and_log!(collection.push(object), LogLevel::Warn);
+        skip_error_and_log!(collection.push(object), tracing::Level::WARN);
     }
     Ok(collection)
 }

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -448,7 +448,7 @@ fn ntfs_with_duplicated_ids() {
             "identifier ME:4bf028:1 already exists",             // Comments
         ];
         for (i, expected_log) in expected_logs.iter().enumerate() {
-            assert_eq!(expected_log.to_string(), captured_warn_logs[i].body);
+            assert!(captured_warn_logs[i].body.contains(expected_log));
         }
     });
 }


### PR DESCRIPTION
:heavy_check_mark: : waiting on CanalTP/skip_error#10 to be merged and released.

This PR does 2 things:
- use `skip_error:2.0.0`
- switch to the new feature `tracing` of `skip_error`