### PR TITLE
[fix] RUST_LOG error message only when invalid

### DIFF
--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -15,13 +15,10 @@ keywords = ["gtfs", "netex", "transit"]
 chrono = "0.4"
 failure = "0.1"
 log = "0.4"
-slog = "2.5"
-slog-async = "2.3"
-slog-envlogger = "2.1"
-slog-scope = "4.1"
-slog-stdlog = "4.0"
-slog-term = "2.4"
 structopt = "0.3"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.2"
 transit_model = { path = "../", features = ["proj"] }
 lazy_static = "1"
 

--- a/gtfs2netexfr/src/main.rs
+++ b/gtfs2netexfr/src/main.rs
@@ -16,10 +16,13 @@
 
 use chrono::{DateTime, FixedOffset};
 use log::info;
-use slog::{slog_o, Drain};
-use slog_async::OverflowStrategy;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
 use transit_model::{read_utils, Result};
 
 lazy_static::lazy_static! {
@@ -81,23 +84,23 @@ struct Opt {
     current_datetime: DateTime<FixedOffset>,
 }
 
-fn init_logger() -> slog_scope::GlobalLoggerGuard {
-    let decorator = slog_term::TermDecorator::new().stdout().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let mut builder = slog_envlogger::LogBuilder::new(drain).filter(None, slog::FilterLevel::Info);
-    if let Ok(s) = std::env::var("RUST_LOG") {
-        builder = builder.parse(&s);
-    }
-    let drain = slog_async::Async::new(builder.build())
-        .chan_size(256) // Double the default size
-        .overflow_strategy(OverflowStrategy::Block)
-        .build()
-        .fuse();
-    let logger = slog::Logger::root(drain, slog_o!());
-
-    let scope_guard = slog_scope::set_global_logger(logger);
-    slog_stdlog::init().unwrap();
-    scope_guard
+fn init_logger() {
+    let default_level = LevelFilter::INFO;
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
+        eprintln!(
+            "invalid {}, falling back to level '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            e,
+        );
+        EnvFilter::new(default_level.to_string())
+    });
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(env_filter_subscriber)
+        .init();
 }
 
 fn run(opt: Opt) -> Result<()> {
@@ -133,7 +136,7 @@ fn run(opt: Opt) -> Result<()> {
 }
 
 fn main() {
-    let _log_guard = init_logger();
+    init_logger();
     if let Err(err) = run(Opt::from_args()) {
         for cause in err.iter_chain() {
             eprintln!("{}", cause);

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -141,17 +141,20 @@ fn run(opt: Opt) -> Result<()> {
 
 fn init_logger() {
     let default_level = LevelFilter::INFO;
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
+        eprintln!(
+            "invalid {}, falling back to level '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            e,
+        );
+        EnvFilter::new(default_level.to_string())
+    });
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer())
-        .with(EnvFilter::try_from_default_env().unwrap_or_else(|e| {
-            eprintln!(
-                "missing or invalid {}, falling back to level '{}' - {}",
-                EnvFilter::DEFAULT_ENV,
-                default_level,
-                e,
-            );
-            EnvFilter::new(default_level.to_string())
-        }))
+        .with(env_filter_subscriber)
         .init();
 }
 

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -15,13 +15,10 @@ keywords = ["gtfs", "ntfs", "transit"]
 chrono = "0.4"
 failure = "0.1"
 log = "0.4"
-slog = "2.5"
-slog-async = "2.3"
-slog-envlogger = "2.1"
-slog-scope = "4.1"
-slog-stdlog = "4.0"
-slog-term = "2.4"
 structopt = "0.3"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.2"
 transit_model = { path = "../" }
 lazy_static = "1"
 

--- a/ntfs2gtfs/src/main.rs
+++ b/ntfs2gtfs/src/main.rs
@@ -16,10 +16,13 @@
 
 use log::info;
 use ntfs2gtfs::add_mode_to_line_code;
-use slog::{slog_o, Drain};
-use slog_async::OverflowStrategy;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
 use transit_model::Result;
 
 lazy_static::lazy_static! {
@@ -46,23 +49,23 @@ struct Opt {
     mode_in_route_short_name: bool,
 }
 
-fn init_logger() -> slog_scope::GlobalLoggerGuard {
-    let decorator = slog_term::TermDecorator::new().stdout().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let mut builder = slog_envlogger::LogBuilder::new(drain).filter(None, slog::FilterLevel::Info);
-    if let Ok(s) = std::env::var("RUST_LOG") {
-        builder = builder.parse(&s);
-    }
-    let drain = slog_async::Async::new(builder.build())
-        .chan_size(256) // Double the default size
-        .overflow_strategy(OverflowStrategy::Block)
-        .build()
-        .fuse();
-    let logger = slog::Logger::root(drain, slog_o!());
-
-    let scope_guard = slog_scope::set_global_logger(logger);
-    slog_stdlog::init().unwrap();
-    scope_guard
+fn init_logger() {
+    let default_level = LevelFilter::INFO;
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
+        eprintln!(
+            "invalid {}, falling back to level '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            e,
+        );
+        EnvFilter::new(default_level.to_string())
+    });
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(env_filter_subscriber)
+        .init();
 }
 
 fn run(opt: Opt) -> Result<()> {
@@ -86,7 +89,7 @@ fn run(opt: Opt) -> Result<()> {
 }
 
 fn main() {
-    let _log_guard = init_logger();
+    init_logger();
     if let Err(err) = run(Opt::from_args()) {
         for cause in err.iter_chain() {
             eprintln!("{}", cause);

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -15,13 +15,10 @@ keywords = ["ntfs", "netex", "transit"]
 chrono = "0.4"
 failure = "0.1"
 log = "0.4"
-slog = "2.5"
-slog-async = "2.3"
-slog-envlogger = "2.1"
-slog-scope = "4.1"
-slog-stdlog = "4.0"
-slog-term = "2.4"
 structopt = "0.3"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.2"
 transit_model = { path = "../", features = ["proj"] }
 lazy_static = "1"
 

--- a/ntfs2netexfr/src/main.rs
+++ b/ntfs2netexfr/src/main.rs
@@ -16,10 +16,13 @@
 
 use chrono::{DateTime, FixedOffset};
 use log::info;
-use slog::{slog_o, Drain};
-use slog_async::OverflowStrategy;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
 use transit_model::Result;
 
 lazy_static::lazy_static! {
@@ -65,23 +68,23 @@ struct Opt {
     current_datetime: DateTime<FixedOffset>,
 }
 
-fn init_logger() -> slog_scope::GlobalLoggerGuard {
-    let decorator = slog_term::TermDecorator::new().stdout().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let mut builder = slog_envlogger::LogBuilder::new(drain).filter(None, slog::FilterLevel::Info);
-    if let Ok(s) = std::env::var("RUST_LOG") {
-        builder = builder.parse(&s);
-    }
-    let drain = slog_async::Async::new(builder.build())
-        .chan_size(256) // Double the default size
-        .overflow_strategy(OverflowStrategy::Block)
-        .build()
-        .fuse();
-    let logger = slog::Logger::root(drain, slog_o!());
-
-    let scope_guard = slog_scope::set_global_logger(logger);
-    slog_stdlog::init().unwrap();
-    scope_guard
+fn init_logger() {
+    let default_level = LevelFilter::INFO;
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
+        eprintln!(
+            "invalid {}, falling back to level '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            e,
+        );
+        EnvFilter::new(default_level.to_string())
+    });
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(env_filter_subscriber)
+        .init();
 }
 
 fn run(opt: Opt) -> Result<()> {
@@ -106,7 +109,7 @@ fn run(opt: Opt) -> Result<()> {
 }
 
 fn main() {
-    let _log_guard = init_logger();
+    init_logger();
     if let Err(err) = run(Opt::from_args()) {
         for cause in err.iter_chain() {
             eprintln!("{}", cause);

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -15,13 +15,10 @@ keywords = ["ntfs", "transit"]
 chrono = "0.4"
 failure = "0.1"
 log = "0.4"
-slog = "2.5"
-slog-async = "2.3"
-slog-envlogger = "2.1"
-slog-scope = "4.1"
-slog-stdlog = "4.0"
-slog-term = "2.4"
 structopt = "0.3"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.2"
 transit_model = { path = "../" }
 lazy_static = "1"
 

--- a/ntfs2ntfs/src/main.rs
+++ b/ntfs2ntfs/src/main.rs
@@ -16,10 +16,13 @@
 
 use chrono::{DateTime, FixedOffset};
 use log::info;
-use slog::{slog_o, Drain};
-use slog_async::OverflowStrategy;
 use std::path::PathBuf;
 use structopt::StructOpt;
+use tracing_subscriber::{
+    filter::{EnvFilter, LevelFilter},
+    layer::SubscriberExt as _,
+    util::SubscriberInitExt as _,
+};
 use transit_model::{transfers::generates_transfers, Result};
 
 lazy_static::lazy_static! {
@@ -64,23 +67,23 @@ struct Opt {
     waiting_time: u32,
 }
 
-fn init_logger() -> slog_scope::GlobalLoggerGuard {
-    let decorator = slog_term::TermDecorator::new().stdout().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let mut builder = slog_envlogger::LogBuilder::new(drain).filter(None, slog::FilterLevel::Info);
-    if let Ok(s) = std::env::var("RUST_LOG") {
-        builder = builder.parse(&s);
-    }
-    let drain = slog_async::Async::new(builder.build())
-        .chan_size(256) // Double the default size
-        .overflow_strategy(OverflowStrategy::Block)
-        .build()
-        .fuse();
-    let logger = slog::Logger::root(drain, slog_o!());
-
-    let scope_guard = slog_scope::set_global_logger(logger);
-    slog_stdlog::init().unwrap();
-    scope_guard
+fn init_logger() {
+    let default_level = LevelFilter::INFO;
+    let rust_log =
+        std::env::var(EnvFilter::DEFAULT_ENV).unwrap_or_else(|_| default_level.to_string());
+    let env_filter_subscriber = EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
+        eprintln!(
+            "invalid {}, falling back to level '{}' - {}",
+            EnvFilter::DEFAULT_ENV,
+            default_level,
+            e,
+        );
+        EnvFilter::new(default_level.to_string())
+    });
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(env_filter_subscriber)
+        .init();
 }
 
 fn run(opt: Opt) -> Result<()> {
@@ -109,7 +112,7 @@ fn run(opt: Opt) -> Result<()> {
 }
 
 fn main() {
-    let _log_guard = init_logger();
+    init_logger();
     if let Err(err) = run(Opt::from_args()) {
         for cause in err.iter_chain() {
             eprintln!("{}", cause);

--- a/restrict-validity-period/Cargo.toml
+++ b/restrict-validity-period/Cargo.toml
@@ -14,11 +14,8 @@ keywords = ["ntfs", "transit"]
 [dependencies]
 chrono = "0.4"
 log = "0.4"
-slog = "2.5"
-slog-async = "2.3"
-slog-envlogger = "2.1"
-slog-scope = "4.1"
-slog-stdlog = "4.0"
-slog-term = "2.4"
 structopt = "0.3"
+tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
+tracing-log = "0.1"
+tracing-subscriber = "0.2"
 transit_model = { path = "../" }


### PR DESCRIPTION
Brings `tracing` to all the binaries without printing an error message when `RUST_LOG` is missing (but will still produce an error message when `RUST_LOG` is invalid).