### PR TITLE
[fix] Revert dedup simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.40.0"
+version = "0.40.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/model.rs
+++ b/src/model.rs
@@ -26,8 +26,9 @@ use serde::{Deserialize, Serialize};
 use skip_error::skip_error_and_log;
 use std::{
     cmp::{self, Ordering, Reverse},
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{hash_map::DefaultHasher, BTreeMap, HashMap, HashSet},
     convert::TryFrom,
+    hash::{Hash, Hasher},
     ops,
 };
 use typed_index_collection::{Collection, CollectionWithId, Id, Idx};
@@ -159,14 +160,19 @@ impl Collections {
             }
         }
 
-        fn dedup_collection<T: PartialEq>(source: &mut Collection<T>) {
-            let mut dedup = Vec::default();
-            for object in source.take() {
-                if !dedup.contains(&object) {
-                    dedup.push(object);
-                }
+        fn dedup_collection<T: Clone + Eq + Hash>(source: &mut Collection<T>) -> Collection<T> {
+            let calculate_hash = |t: &T| -> u64 {
+                let mut s = DefaultHasher::new();
+                t.hash(&mut s);
+                s.finish()
+            };
+            let mut set: BTreeMap<u64, T> = BTreeMap::new();
+            let items = source.take();
+            for item in items {
+                set.insert(calculate_hash(&item), item);
             }
-            *source = Collection::new(dedup);
+            let collection: Vec<T> = set.values().cloned().collect();
+            Collection::new(collection)
         }
 
         self.calendars
@@ -480,18 +486,18 @@ impl Collections {
             .retain(|level| level_id_used.contains(&level.id));
         self.calendars.retain(|c| calendars_used.contains(&c.id));
 
-        dedup_collection(&mut self.frequencies);
-        dedup_collection(&mut self.transfers);
-        dedup_collection(&mut self.admin_stations);
-        dedup_collection(&mut self.prices_v1);
-        dedup_collection(&mut self.od_fares_v1);
-        dedup_collection(&mut self.fares_v1);
-        dedup_collection(&mut self.ticket_prices);
-        dedup_collection(&mut self.ticket_use_perimeters);
-        dedup_collection(&mut self.ticket_use_restrictions);
-        dedup_collection(&mut self.grid_exception_dates);
-        dedup_collection(&mut self.grid_periods);
-        dedup_collection(&mut self.grid_rel_calendar_line);
+        self.frequencies = dedup_collection(&mut self.frequencies);
+        self.transfers = dedup_collection(&mut self.transfers);
+        self.admin_stations = dedup_collection(&mut self.admin_stations);
+        self.prices_v1 = dedup_collection(&mut self.prices_v1);
+        self.od_fares_v1 = dedup_collection(&mut self.od_fares_v1);
+        self.fares_v1 = dedup_collection(&mut self.fares_v1);
+        self.ticket_prices = dedup_collection(&mut self.ticket_prices);
+        self.ticket_use_perimeters = dedup_collection(&mut self.ticket_use_perimeters);
+        self.ticket_use_restrictions = dedup_collection(&mut self.ticket_use_restrictions);
+        self.grid_exception_dates = dedup_collection(&mut self.grid_exception_dates);
+        self.grid_periods = dedup_collection(&mut self.grid_periods);
+        self.grid_rel_calendar_line = dedup_collection(&mut self.grid_rel_calendar_line);
 
         Ok(())
     }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -31,7 +31,7 @@ use std::str::FromStr;
 use thiserror::Error;
 use typed_index_collection::{impl_id, impl_with_id, Idx, WithId};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum ObjectType {
     StopArea,
@@ -727,7 +727,7 @@ impl VehicleJourney {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Frequency {
     #[serde(rename = "trip_id")]
     pub vehicle_journey_id: String,
@@ -755,7 +755,7 @@ impl From<std::num::ParseIntError> for TimeError {
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Time(u32);
 impl Time {
     pub fn new(h: u32, m: u32, s: u32) -> Time {
@@ -1514,6 +1514,14 @@ impl AddPrefix for Transfer {
     }
 }
 
+impl Hash for Transfer {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (&self.from_stop_id, &self.to_stop_id).hash(state);
+    }
+}
+
+impl Eq for Transfer {}
+
 #[derive(Serialize, Deserialize, Debug, Derivative, PartialEq, Clone)]
 #[derivative(Default)]
 pub enum TransportType {
@@ -1589,7 +1597,7 @@ impl AddPrefix for Geometry {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct AdminStation {
     pub admin_id: String,
     pub admin_name: String,
@@ -1603,7 +1611,7 @@ impl AddPrefix for AdminStation {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct PriceV1 {
     pub id: String,
     #[serde(
@@ -1629,7 +1637,7 @@ impl AddPrefix for PriceV1 {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct OdFareV1 {
     #[serde(rename = "Origin ID")]
     pub origin_stop_area_id: String,
@@ -1656,7 +1664,7 @@ impl AddPrefix for OdFareV1 {
     }
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Default, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct FareV1 {
     #[serde(rename = "avant changement")]
     pub before_change: String,
@@ -1701,7 +1709,7 @@ impl AddPrefix for Ticket {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct TicketPrice {
     pub ticket_id: String,
     #[serde(rename = "ticket_price", deserialize_with = "de_positive_decimal")]
@@ -1748,7 +1756,7 @@ impl AddPrefix for TicketUse {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub enum PerimeterAction {
     #[serde(rename = "1")]
     Included,
@@ -1756,7 +1764,7 @@ pub enum PerimeterAction {
     Excluded,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct TicketUsePerimeter {
     pub ticket_use_id: String,
     pub object_type: ObjectType,
@@ -1771,7 +1779,7 @@ impl AddPrefix for TicketUsePerimeter {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub enum RestrictionType {
     #[serde(rename = "zone")]
     Zone,
@@ -1779,7 +1787,7 @@ pub enum RestrictionType {
     OriginDestination,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct TicketUseRestriction {
     pub ticket_use_id: String,
     pub restriction_type: RestrictionType,
@@ -1823,7 +1831,7 @@ impl AddPrefix for GridCalendar {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct GridExceptionDate {
     pub grid_calendar_id: String,
     #[serde(
@@ -1842,7 +1850,7 @@ impl AddPrefix for GridExceptionDate {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
 pub struct GridPeriod {
     pub grid_calendar_id: String,
     #[serde(
@@ -1864,7 +1872,7 @@ impl AddPrefix for GridPeriod {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct GridRelCalendarLine {
     pub grid_calendar_id: String,
     pub line_id: String,

--- a/tests/fixtures/netex_france/output/correspondances.xml
+++ b/tests/fixtures/netex_france/output/correspondances.xml
@@ -5,20 +5,37 @@
 	<dataObjects>
 		<GeneralFrame id="FR:GeneralFrame:NETEX_RESEAU:" version="any">
 			<members>
-				<SiteConnection id="FR:SiteConnection:GDLR_GDLM:" version="any">
+				<SiteConnection id="FR:SiteConnection:GDLB_GDLM:" version="any">
 					<WalkTransferDuration>
-						<DefaultDuration>PT180S</DefaultDuration>
+						<DefaultDuration>PT120S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
 						<StopPlaceRef ref="FR:StopPlace:GDL:">
 						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLR:">
+						<QuayRef ref="FR:Quay:GDLB:">
 						</QuayRef>
 					</From>
 					<To>
 						<StopPlaceRef ref="FR:StopPlace:GDL:">
 						</StopPlaceRef>
 						<QuayRef ref="FR:Quay:GDLM:">
+						</QuayRef>
+					</To>
+				</SiteConnection>
+				<SiteConnection id="FR:SiteConnection:GDLM_GDLB:" version="any">
+					<WalkTransferDuration>
+						<DefaultDuration>PT120S</DefaultDuration>
+					</WalkTransferDuration>
+					<From>
+						<StopPlaceRef ref="FR:StopPlace:GDL:">
+						</StopPlaceRef>
+						<QuayRef ref="FR:Quay:GDLM:">
+						</QuayRef>
+					</From>
+					<To>
+						<StopPlaceRef ref="FR:StopPlace:GDL:">
+						</StopPlaceRef>
+						<QuayRef ref="FR:Quay:GDLB:">
 						</QuayRef>
 					</To>
 				</SiteConnection>
@@ -73,31 +90,14 @@
 						</QuayRef>
 					</To>
 				</SiteConnection>
-				<SiteConnection id="FR:SiteConnection:GDLM_GDLB:" version="any">
+				<SiteConnection id="FR:SiteConnection:GDLR_GDLM:" version="any">
 					<WalkTransferDuration>
-						<DefaultDuration>PT120S</DefaultDuration>
+						<DefaultDuration>PT180S</DefaultDuration>
 					</WalkTransferDuration>
 					<From>
 						<StopPlaceRef ref="FR:StopPlace:GDL:">
 						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLM:">
-						</QuayRef>
-					</From>
-					<To>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLB:">
-						</QuayRef>
-					</To>
-				</SiteConnection>
-				<SiteConnection id="FR:SiteConnection:GDLB_GDLM:" version="any">
-					<WalkTransferDuration>
-						<DefaultDuration>PT120S</DefaultDuration>
-					</WalkTransferDuration>
-					<From>
-						<StopPlaceRef ref="FR:StopPlace:GDL:">
-						</StopPlaceRef>
-						<QuayRef ref="FR:Quay:GDLB:">
+						<QuayRef ref="FR:Quay:GDLR:">
 						</QuayRef>
 					</From>
 					<To>


### PR DESCRIPTION
ref: https://jira.kisio.org/browse/ND-1572

The commit  https://github.com/CanalTP/transit_model/pull/786/commits/c93a60d9e0c6614d259a0fa0ea4474c6c778eb28 from https://github.com/CanalTP/transit_model/pull/786 deteriorates the performance. I reverted a part of the commit

ntfs2ntfs on a 132MB NTFS

Before > 23min, 2,1 GB Ram
After ~2 min, 3 GB Ram