### PR TITLE
[feature] support 'ntfs:v0.12.1'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.41.1"
+version = "0.41.2"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod version_utils;
 pub mod vptranslator;
 
 /// Current version of the NTFS format
-pub const NTFS_VERSION: &str = "0.12.0";
+pub const NTFS_VERSION: &str = "0.12.1";
 
 /// The max distance in meters to compute the transfer
 pub const TRANSFER_MAX_DISTANCE: &str = "300";

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -465,7 +465,7 @@ mod tests {
                     ("feed_end_date".to_string(), "20180131".to_string()),
                     ("feed_publisher_name".to_string(), "Nicaragua".to_string()),
                     ("feed_start_date".to_string(), "20180130".to_string()),
-                    ("ntfs_version".to_string(), "0.12.0".to_string()),
+                    ("ntfs_version".to_string(), "0.12.1".to_string()),
                     ("tartare_platform".to_string(), "dev".to_string()),
                 ],
                 collections

--- a/tests/fixtures/gtfs2ntfs/full_output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/full_output/feed_infos.txt
@@ -7,6 +7,6 @@ feed_license,DefaultDatasourceLicense
 feed_license_url,http://www.default-datasource-website.com
 feed_publisher_name,DefaultContributorName
 feed_start_date,20180101
-ntfs_version,0.12.0
+ntfs_version,0.12.1
 tartare_contributor_id,DefaultContributorId
 tartare_platform,dev

--- a/tests/fixtures/gtfs2ntfs/minimal/output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/minimal/output/feed_infos.txt
@@ -4,4 +4,4 @@ feed_creation_time,17:19:00
 feed_creation_datetime,2019-04-03T17:19:00+00:00
 feed_end_date,20180106
 feed_start_date,20180101
-ntfs_version,0.12.0
+ntfs_version,0.12.1

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output/feed_infos.txt
@@ -4,4 +4,4 @@ feed_creation_time,17:19:00
 feed_creation_datetime,2019-04-03T17:19:00+00:00
 feed_end_date,20180106
 feed_start_date,20180101
-ntfs_version,0.12.0
+ntfs_version,0.12.1

--- a/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/feed_infos.txt
+++ b/tests/fixtures/gtfs2ntfs/routes_comments/output_as_lines/feed_infos.txt
@@ -4,4 +4,4 @@ feed_creation_time,17:19:00
 feed_creation_datetime,2019-04-03T17:19:00+00:00
 feed_end_date,20180106
 feed_start_date,20180101
-ntfs_version,0.12.0
+ntfs_version,0.12.1

--- a/tests/fixtures/restrict-validity-period/output/feed_infos.txt
+++ b/tests/fixtures/restrict-validity-period/output/feed_infos.txt
@@ -4,4 +4,4 @@ feed_creation_time,17:19:00
 feed_creation_datetime,2019-04-03T17:19:00+00:00
 feed_end_date,20180805
 feed_start_date,20180501
-ntfs_version,0.12.0
+ntfs_version,0.12.1


### PR DESCRIPTION
`ntfs:v0.12.1` (compared to `v0.12.0`) introduce the possible value `3` in the fields `drop_off_type` and `pickup_type` of `stop_times.txt`. There is nothing much to do since these fields are implemented as `u8` (so the value `3` is already supported).