### PR TITLE
[tech] remove incremental build for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
             - 'master'
     pull_request:  # Build any PR
 
+env:
+  CARGO_INCREMENTAL: 0
+
 jobs:
   rustfmt:
     name: Formatting check


### PR DESCRIPTION
Current builds are hardly going under 10mn (for PR on CI, I'm not talking about releases). In CI, we don't really need the compiler to generate incremental metadata to be able to compile faster on next run so how about dseems teactivating it? I'm opening this PR in draft so we can check if this does make a difference.

I'm not innovating here, I'm just borrowing some ideas from [`rust-analyzer`](https://github.com/rust-analyzer/rust-analyzer/blob/25368d24308d6a94ffe8b99f0122bcf5a2175322/.github/workflows/ci.yaml#L11). It's only one of a few ideas exposed in [`matklad` article](https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow).