### PR TITLE
[tech] Fix StopLocation reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.42.0"
+version = "0.42.1"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/src/ntfs/read.rs
+++ b/src/ntfs/read.rs
@@ -139,7 +139,7 @@ impl TryFrom<Stop> for StopLocation {
             name: stop.name,
             code: stop.code,
             comment_links: CommentLinksT::default(),
-            visible: false,
+            visible: stop.visible,
             coord,
             parent_id: stop.parent_station,
             timezone: stop.timezone,


### PR DESCRIPTION
Surely an old mistake. 
A StopLocation (like an entry or an exit) "visible" in an ntfs (csv) goes "invisible" at loading / ntfs reading.