### PR TITLE
update outdated dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   clippy:
     name: Analyzing code with Clippy
     runs-on: ubuntu-latest
-    container: kisiodigital/rust-ci:latest-proj7.2.1
+    container: kisiodigital/rust-ci:latest-proj8.1.0
     steps:
     - uses: actions/checkout@master
     - name: Linting
@@ -46,7 +46,7 @@ jobs:
   audit:
     name: Audits
     runs-on: ubuntu-latest
-    container: kisiodigital/rust-ci:latest-proj7.2.1
+    container: kisiodigital/rust-ci:latest-proj8.1.0
     continue-on-error: true
     steps:
     - uses: actions/checkout@v1
@@ -67,7 +67,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: kisiodigital/rust-ci:latest-proj7.2.1
+    container: kisiodigital/rust-ci:latest-proj8.1.0
     steps:
     - name: Checkout repository and submodules
       uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    container: kisiodigital/rust-ci:latest-proj7.2.1
+    container: kisiodigital/rust-ci:latest-proj8.1.0
     steps:
     - uses: actions/checkout@master
     - name: Cargo login

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Kisio Digital <team.coretools@kisio.com>", "Guillaume Pinot <texitoi@texitoi.eu>"]
 name = "transit_model"
-version = "0.42.1"
+version = "0.42.2"
 license = "AGPL-3.0-only"
 description = "Transit data management"
 repository = "https://github.com/CanalTP/transit_model"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ mutable-model = []
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-chrono-tz = { version = "0.5", features = ["serde"] }
+chrono-tz = { version = "0.6", features = ["serde"] }
 csv = "1"
 derivative = "2"
 failure = "0.1"
@@ -51,8 +51,8 @@ minidom = "0.12"
 minidom_ext = "1"
 minidom_writer = "1"
 num-traits = "0.2"
-pretty_assertions = "0.7"
-proj = { version = "0.22", optional = true } # libproj version used by 'proj' crate must be propagated to CI and makefile
+pretty_assertions = "1"
+proj = { version = "0.24", optional = true } # libproj version used by 'proj' crate must be propagated to CI and makefile
 quick-xml = "0.22"
 relational_types = "2"
 rust_decimal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,11 @@ xmllint = ["proj"]
 mutable-model = []
 
 [dependencies]
+anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 chrono-tz = { version = "0.6", features = ["serde"] }
 csv = "1"
 derivative = "2"
-failure = "0.1"
 geo = "0.18"
 iso4217 = "0.3"
 lazy_static = "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM kisiodigital/rust-ci:latest-proj7.2.1 as builder
+FROM kisiodigital/rust-ci:latest-proj8.1.0 as builder
 WORKDIR /usr/src/app
 COPY . ./
 RUN git describe --tags --always && git status
 RUN cargo build --workspace --release
 RUN mkdir /usr/src/bin && for file in ls ${CARGO_TARGET_DIR:-./target}/release/*; do if test -f $file -a -x $file; then cp $file /usr/src/bin; fi; done
 
-FROM kisiodigital/proj-ci:7.2.1
+FROM kisiodigital/proj-ci:8.1.0
 COPY --from=builder /usr/src/bin/* /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Version required by `proj` crate used in cargo.toml
-PROJ_VERSION = 7.2.1
+PROJ_VERSION = 8.1.0
 
 install_proj_deps: ## Install dependencies the proj crate needs in order to build libproj from source
 	sudo apt update

--- a/examples/gtfs_reader.rs
+++ b/examples/gtfs_reader.rs
@@ -26,7 +26,7 @@ fn run() -> Result<()> {
 
 fn main() {
     if let Err(err) = run() {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/examples/ntfs_crawler.rs
+++ b/examples/ntfs_crawler.rs
@@ -61,7 +61,7 @@ fn run() -> Result<()> {
 
 fn main() {
     if let Err(err) = run() {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtfs2netexfr"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from GTFS format to NeTEx France"

--- a/gtfs2netexfr/Cargo.toml
+++ b/gtfs2netexfr/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["gtfs", "netex", "transit"]
 
 [dependencies]
+anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"

--- a/gtfs2netexfr/src/main.rs
+++ b/gtfs2netexfr/src/main.rs
@@ -138,7 +138,7 @@ fn run(opt: Opt) -> Result<()> {
 fn main() {
     init_logger();
     if let Err(err) = run(Opt::from_args()) {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtfs2ntfs"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from GTFS format to NTFS"

--- a/gtfs2ntfs/Cargo.toml
+++ b/gtfs2ntfs/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["gtfs", "ntfs", "transit"]
 
 [dependencies]
+anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"

--- a/gtfs2ntfs/src/main.rs
+++ b/gtfs2ntfs/src/main.rs
@@ -161,7 +161,7 @@ fn init_logger() {
 fn main() {
     init_logger();
     if let Err(err) = run(Opt::from_args()) {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntfs2gtfs"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from NTFS format to GTFS"

--- a/ntfs2gtfs/Cargo.toml
+++ b/ntfs2gtfs/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["gtfs", "ntfs", "transit"]
 
 [dependencies]
+anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"

--- a/ntfs2gtfs/src/main.rs
+++ b/ntfs2gtfs/src/main.rs
@@ -93,7 +93,7 @@ fn run(opt: Opt) -> Result<()> {
 fn main() {
     init_logger();
     if let Err(err) = run(Opt::from_args()) {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntfs2netexfr"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to convert Transit data from NTFS format to NeTEx France"

--- a/ntfs2netexfr/Cargo.toml
+++ b/ntfs2netexfr/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["ntfs", "netex", "transit"]
 
 [dependencies]
+anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"

--- a/ntfs2netexfr/src/main.rs
+++ b/ntfs2netexfr/src/main.rs
@@ -113,7 +113,7 @@ fn run(opt: Opt) -> Result<()> {
 fn main() {
     init_logger();
     if let Err(err) = run(Opt::from_args()) {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["command-line-utilities", "data-structures", "encoding", "parser-i
 keywords = ["ntfs", "transit"]
 
 [dependencies]
+anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-failure = "0.1"
 structopt = "0.3"
 tracing = { version = "0.1", features = ["log", "release_max_level_info"] }
 tracing-log = "0.1"

--- a/ntfs2ntfs/Cargo.toml
+++ b/ntfs2ntfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ntfs2ntfs"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "AGPL-3.0-only"
 description = "Binary to check and clean a NTFS"

--- a/ntfs2ntfs/src/main.rs
+++ b/ntfs2ntfs/src/main.rs
@@ -114,7 +114,7 @@ fn run(opt: Opt) -> Result<()> {
 fn main() {
     init_logger();
     if let Err(err) = run(Opt::from_args()) {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/restrict-validity-period/src/main.rs
+++ b/restrict-validity-period/src/main.rs
@@ -91,7 +91,7 @@ fn run(opt: Opt) -> Result<()> {
 fn main() {
     init_logger();
     if let Err(err) = run(Opt::from_args()) {
-        for cause in err.iter_chain() {
+        for cause in err.chain() {
             eprintln!("{}", cause);
         }
         std::process::exit(1);

--- a/src/calendars.rs
+++ b/src/calendars.rs
@@ -24,8 +24,8 @@ use crate::utils::*;
 use crate::utils::{de_from_date_string, ser_from_naive_date};
 use crate::vptranslator::translate;
 use crate::Result;
+use anyhow::{anyhow, bail, Context};
 use chrono::{self, Datelike, Weekday};
-use failure::{bail, format_err, ResultExt};
 use serde::{Deserialize, Serialize};
 use skip_error::skip_error_and_warn;
 use std::collections::BTreeSet;
@@ -202,7 +202,7 @@ pub fn write_calendar_dates(
         let translation = translate(&c.dates);
         if !translation.operating_days.is_empty() {
             let validity_period = skip_error_and_warn!(translation.validity_period.ok_or_else(
-                || format_err!("Validity period not found for service id {}", c.id.clone())
+                || anyhow!("Validity period not found for service id {}", c.id.clone())
             ));
             translations.push(Calendar {
                 id: c.id.clone(),
@@ -227,13 +227,13 @@ pub fn write_calendar_dates(
     }
     if !exceptions.is_empty() {
         let mut wtr = csv::Writer::from_path(&calendar_dates_path)
-            .with_context(|_| format!("Error reading {:?}", calendar_dates_path))?;
+            .with_context(|| format!("Error reading {:?}", calendar_dates_path))?;
         for e in exceptions {
             wtr.serialize(&e)
-                .with_context(|_| format!("Error reading {:?}", calendar_dates_path))?;
+                .with_context(|| format!("Error reading {:?}", calendar_dates_path))?;
         }
         wtr.flush()
-            .with_context(|_| format!("Error reading {:?}", calendar_dates_path))?;
+            .with_context(|| format!("Error reading {:?}", calendar_dates_path))?;
     }
     write_calendar(path, &translations)
 }
@@ -247,12 +247,12 @@ pub fn write_calendar(path: &path::Path, calendars: &[Calendar]) -> Result<()> {
 
     let calendar_path = path.join("calendar.txt");
     let mut wtr = csv::Writer::from_path(&calendar_path)
-        .with_context(|_| format!("Error reading {:?}", calendar_path))?;
+        .with_context(|| format!("Error reading {:?}", calendar_path))?;
     for calendar in calendars {
         wtr.serialize(calendar)
-            .with_context(|_| format!("Error reading {:?}", calendar_path))?;
+            .with_context(|| format!("Error reading {:?}", calendar_path))?;
     }
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", calendar_path))?;
+        .with_context(|| format!("Error reading {:?}", calendar_path))?;
     Ok(())
 }

--- a/src/gtfs/mod.rs
+++ b/src/gtfs/mod.rs
@@ -26,9 +26,9 @@ use crate::{
     utils::*,
     validity_period, AddPrefix, PrefixConfiguration, Result,
 };
+use anyhow::{anyhow, Context};
 use chrono_tz::Tz;
 use derivative::Derivative;
-use failure::ResultExt;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt, path::Path};
 use tracing::info;
@@ -401,13 +401,13 @@ impl Reader {
             // if it's a file, we consider it to be a zip (and an error will be returned if it is not)
             Ok(self
                 .parse_zip(p)
-                .with_context(|_| format!("impossible to read zipped gtfs {:?}", p))?)
+                .with_context(|| format!("impossible to read zipped gtfs {:?}", p))?)
         } else if p.is_dir() {
             Ok(self
                 .parse_dir(p)
-                .with_context(|_| format!("impossible to read gtfs directory from {:?}", p))?)
+                .with_context(|| format!("impossible to read gtfs directory from {:?}", p))?)
         } else {
-            Err(failure::format_err!(
+            Err(anyhow!(
                 "file {:?} is neither a file nor a directory, cannot read a gtfs from it",
                 p
             ))

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -27,8 +27,8 @@ use crate::{
     utils::*,
     Result,
 };
+use anyhow::{anyhow, bail, Error};
 use derivative::Derivative;
-use failure::{bail, format_err, Error};
 use geo::{LineString, Point};
 use serde::Deserialize;
 use skip_error::{skip_error_and_warn, SkipError};
@@ -529,7 +529,7 @@ fn interpolate_undefined_stop_times(
         if !undefined_stops_bulk.is_empty() {
             let values = ventilate_stop_times(
                 &undefined_stops_bulk,
-                res.last().ok_or_else(|| format_err!("the first stop time of the vj '{}' has no departure/arrival, the stop_times.txt file is not valid", vj_id))?,
+                res.last().ok_or_else(|| anyhow!("the first stop time of the vj '{}' has no departure/arrival, the stop_times.txt file is not valid", vj_id))?,
                 &st_value,
             );
             res.extend(values);
@@ -539,7 +539,7 @@ fn interpolate_undefined_stop_times(
     }
 
     if !undefined_stops_bulk.is_empty() {
-        Err(format_err!("the last stop time of the vj '{}' has no departure/arrival, the stop_times.txt file is not valid", vj_id))
+        Err(anyhow!("the last stop time of the vj '{}' has no departure/arrival, the stop_times.txt file is not valid", vj_id))
     } else {
         Ok(res)
     }
@@ -796,7 +796,7 @@ where
                 .get(&pathway.from_stop_id)
                 .map(|sl| sl.stop_type.clone()))
             .ok_or_else(|| {
-                format_err!(
+                anyhow!(
                     "Problem reading {:?}: from_stop_id={:?} not found",
                     file,
                     pathway.from_stop_id
@@ -812,7 +812,7 @@ where
                 .get(&pathway.to_stop_id)
                 .map(|sl| sl.stop_type.clone()))
             .ok_or_else(|| {
-                format_err!(
+                anyhow!(
                     "Problem reading {:?}: to_stop_id={:?} not found",
                     file,
                     pathway.to_stop_id
@@ -848,7 +848,7 @@ where
                 stop_points
                     .get(stop_id)
                     .ok_or_else(|| {
-                        format_err!(
+                        anyhow!(
                             "Problem reading {:?}: stop_id={:?} not found",
                             file,
                             stop_id
@@ -1207,7 +1207,7 @@ where
             .vehicle_journeys
             .get(&frequency.trip_id)
             .cloned()
-            .ok_or_else(|| format_err!(
+            .ok_or_else(|| anyhow!(
                 "frequency mapped to an unexisting trip {:?}",
                 frequency.trip_id
             )));
@@ -1405,9 +1405,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "IdentifierAlreadyExists Error { id: \"1\", type: \"transit_model::objects::Network\" }"
-    )]
+    #[should_panic(expected = "`Err` value: identifier 1 already exists")]
     fn load_2_agencies_with_no_id() {
         let agency_content = "agency_name,agency_url,agency_timezone\n\
                               My agency 1,http://my-agency_url.com,Europe/London\n\

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -929,13 +929,10 @@ fn get_modes_from_gtfs(
     let gtfs_mode_types: BTreeSet<RouteType> =
         gtfs_routes.values().map(|r| r.route_type.clone()).collect();
 
-    let commercial_modes = gtfs_mode_types
-        .iter()
-        .map(|mt| get_commercial_mode(mt))
-        .collect();
+    let commercial_modes = gtfs_mode_types.iter().map(get_commercial_mode).collect();
     let physical_modes = gtfs_mode_types
         .iter()
-        .map(|mt| get_physical_mode(mt))
+        .map(get_physical_mode)
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect();

--- a/src/gtfs/read.rs
+++ b/src/gtfs/read.rs
@@ -1343,7 +1343,7 @@ mod tests {
     use typed_index_collection::Id;
 
     fn extract<'a, T, S: ::std::cmp::Ord>(f: fn(&'a T) -> S, c: &'a Collection<T>) -> Vec<S> {
-        let mut extracted_props: Vec<S> = c.values().map(|l| f(l)).collect();
+        let mut extracted_props: Vec<S> = c.values().map(f).collect();
         extracted_props.sort();
         extracted_props
     }

--- a/src/gtfs/write.rs
+++ b/src/gtfs/write.rs
@@ -21,7 +21,7 @@ use crate::objects;
 use crate::objects::Transfer as NtfsTransfer;
 use crate::objects::*;
 use crate::Result;
-use failure::ResultExt;
+use anyhow::Context;
 use geo::Geometry as GeoGeometry;
 use relational_types::IdxSet;
 use serde::{Deserialize, Serialize};
@@ -37,16 +37,16 @@ pub fn write_transfers(path: &path::Path, transfers: &Collection<NtfsTransfer>) 
     info!("Writing transfers.txt");
     let path = path.join("transfers.txt");
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for t in transfers.values() {
         if t.from_stop_id != t.to_stop_id {
             wtr.serialize(Transfer::from(t))
-                .with_context(|_| format!("Error reading {:?}", path))?;
+                .with_context(|| format!("Error reading {:?}", path))?;
         }
     }
 
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -58,14 +58,14 @@ pub fn write_agencies(
     info!("Writing agency.txt");
     let path = path.join("agency.txt");
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for n in networks.values() {
         wtr.serialize(Agency::from(n))
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
 
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -184,25 +184,25 @@ pub fn write_stops(
     info!("Writing {}", file);
     let path = path.join(file);
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     info!("Writing {} from StopPoint", file);
     for sp in stop_points.values() {
         wtr.serialize(ntfs_stop_point_to_gtfs_stop(sp, comments, equipments))
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
     info!("Writing {} from StopArea", file);
     for sa in stop_areas.values() {
         wtr.serialize(ntfs_stop_area_to_gtfs_stop(sa, comments, equipments))
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
     info!("Writing {} from StopLocation", file);
     for sl in stop_locations.values() {
         wtr.serialize(ntfs_stop_location_to_gtfs_stop(sl, comments, equipments))
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
 
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -247,14 +247,14 @@ pub fn write_trips(path: &path::Path, model: &Model) -> Result<()> {
     info!("Writing trips.txt");
     let path = path.join("trips.txt");
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for vj in model.vehicle_journeys.values() {
         wtr.serialize(make_gtfs_trip_from_ntfs_vj(vj, model))
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
 
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -298,13 +298,13 @@ pub fn write_stop_extensions(
     info!("Writing stop_extensions.txt");
     let path = path.join("stop_extensions.txt");
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for se in stop_extensions {
         wtr.serialize(se)
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -401,16 +401,16 @@ pub fn write_routes(path: &path::Path, model: &Model) -> Result<()> {
     info!("Writing routes.txt");
     let path = path.join("routes.txt");
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for (from, l) in &model.lines {
         for pm in &get_line_physical_modes(from, &model.physical_modes, model) {
             wtr.serialize(make_gtfs_route_from_ntfs_line(l, pm))
-                .with_context(|_| format!("Error reading {:?}", path))?;
+                .with_context(|| format!("Error reading {:?}", path))?;
         }
     }
 
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -424,7 +424,7 @@ pub fn write_stop_times(
     info!("Writing stop_times.txt");
     let stop_times_path = path.join("stop_times.txt");
     let mut st_wtr = csv::Writer::from_path(&stop_times_path)
-        .with_context(|_| format!("Error reading {:?}", stop_times_path))?;
+        .with_context(|| format!("Error reading {:?}", stop_times_path))?;
     for (vj_idx, vj) in vehicle_journeys {
         for st in &vj.stop_times {
             st_wtr
@@ -442,12 +442,12 @@ pub fn write_stop_times(
                         .cloned(),
                     timepoint: !st.datetime_estimated,
                 })
-                .with_context(|_| format!("Error reading {:?}", st_wtr))?;
+                .with_context(|| format!("Error reading {:?}", st_wtr))?;
         }
     }
     st_wtr
         .flush()
-        .with_context(|_| format!("Error reading {:?}", stop_times_path))?;
+        .with_context(|| format!("Error reading {:?}", stop_times_path))?;
     Ok(())
 }
 
@@ -483,12 +483,12 @@ pub fn write_shapes(
         info!("Writing shapes.txt");
         let path = path.join("shapes.txt");
         let mut wtr =
-            csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+            csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
         wtr.flush()
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
         for shape in shapes {
             wtr.serialize(shape)
-                .with_context(|_| format!("Error reading {:?}", path))?;
+                .with_context(|| format!("Error reading {:?}", path))?;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ lazy_static::lazy_static! {
 }
 
 /// The error type used by the crate.
-pub type Error = failure::Error;
+pub type Error = anyhow::Error;
 
 /// The corresponding result type used by the crate.
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,9 +15,9 @@
 //! Definition of the navitia transit model.
 
 use crate::{enhancers, objects::*, Error, Result};
+use anyhow::{anyhow, bail};
 use chrono::NaiveDate;
 use derivative::Derivative;
-use failure::{bail, format_err};
 use geo::algorithm::centroid::Centroid;
 use geo::MultiPoint;
 use relational_types::{GetCorresponding, IdxSet, ManyToMany, OneToMany, Relation};
@@ -588,13 +588,13 @@ impl Collections {
                 .first()
                 .map(|st| st.departure_time)
                 .map(|departure_time| departure_time % SECONDS_PER_DAY)
-                .ok_or_else(|| format_err!("undefined departure time for vj {}", vj.id))?;
+                .ok_or_else(|| anyhow!("undefined departure time for vj {}", vj.id))?;
             let vj_arrival_time = vj
                 .stop_times
                 .last()
                 .map(|st| st.arrival_time)
                 .map(|arrival_time| arrival_time % SECONDS_PER_DAY)
-                .ok_or_else(|| format_err!("undefined arrival time for vj {}", vj.id))?;
+                .ok_or_else(|| anyhow!("undefined arrival time for vj {}", vj.id))?;
             let departure_hour = u8::try_from(vj_departure_time.hours())?;
             let arrival_hour = u8::try_from(vj_arrival_time.hours())?;
             opening_timetable
@@ -1252,10 +1252,10 @@ impl Model {
             .map(|(idx, tr)| {
                 let mut stop_points = IdxSet::default();
                 stop_points.insert(c.stop_points.get_idx(&tr.from_stop_id).ok_or_else(|| {
-                    format_err!("Invalid id: transfer.from_stop_id={:?}", tr.from_stop_id)
+                    anyhow!("Invalid id: transfer.from_stop_id={:?}", tr.from_stop_id)
                 })?);
                 stop_points.insert(c.stop_points.get_idx(&tr.to_stop_id).ok_or_else(|| {
-                    format_err!("Invalid id: transfer.to_stop_id={:?}", tr.to_stop_id)
+                    anyhow!("Invalid id: transfer.to_stop_id={:?}", tr.to_stop_id)
                 })?);
                 Ok((idx, stop_points))
             })
@@ -1384,7 +1384,7 @@ impl Model {
         self.collections
             .calendars
             .push(calendar)
-            .map_err(|e| format_err!("{}", e))
+            .map_err(|e| anyhow!("{}", e))
     }
     /// Add a new relation between a calendar and some vehicle journeys
     pub fn connect_calendar_to_vehicle_journeys(

--- a/src/netex_france/calendars.rs
+++ b/src/netex_france/calendars.rs
@@ -17,8 +17,8 @@ use crate::{
     objects::{Calendar, Date},
     Model, Result,
 };
+use anyhow::bail;
 use chrono::prelude::*;
-use failure::bail;
 use minidom::{Element, Node};
 use std::collections::BTreeSet;
 

--- a/src/netex_france/exporter.rs
+++ b/src/netex_france/exporter.rs
@@ -23,8 +23,8 @@ use crate::{
     objects::{Date, Line, Network},
     Result,
 };
+use anyhow::anyhow;
 use chrono::prelude::*;
-use failure::format_err;
 use minidom::{Element, Node};
 use minidom_writer::ElementWriter;
 use proj::Proj;
@@ -175,7 +175,7 @@ impl<'a> Exporter<'a> {
         let from = "+proj=longlat +datum=WGS84 +no_defs"; // https://epsg.io/4326
         let to = "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"; // https://epsg.io/2154
         Proj::new_known_crs(from, to, None)
-            .ok_or_else(|| format_err!("Proj cannot build a converter from '{}' to '{}'", from, to))
+            .ok_or_else(|| anyhow!("Proj cannot build a converter from '{}' to '{}'", from, to))
     }
 }
 

--- a/src/netex_france/lines.rs
+++ b/src/netex_france/lines.rs
@@ -20,7 +20,7 @@ use crate::{
     objects::Line,
     Model, Result,
 };
-use failure::format_err;
+use anyhow::anyhow;
 use minidom::{Element, Node};
 use std::collections::{BTreeSet, HashMap};
 
@@ -81,9 +81,9 @@ impl<'a> LineExporter<'a> {
         let netex_modes = self
             .line_modes
             .get(line.id.as_str())
-            .ok_or_else(|| format_err!("Unable to find modes for Line '{}'", line.id))?;
+            .ok_or_else(|| anyhow!("Unable to find modes for Line '{}'", line.id))?;
         let highest_netex_mode = NetexMode::calculate_highest_mode(netex_modes)
-            .ok_or_else(|| format_err!("Unable to resolve main NeTEx mode for Line {}", line.id))?;
+            .ok_or_else(|| anyhow!("Unable to resolve main NeTEx mode for Line {}", line.id))?;
         let element_builder = element_builder
             .append(self.generate_name(line))
             .append(self.generate_transport_mode(highest_netex_mode));

--- a/src/netex_france/offer.rs
+++ b/src/netex_france/offer.rs
@@ -21,7 +21,7 @@ use crate::{
     objects::{Coord, Line, Route, StopPoint, StopTime, Time, VehicleJourney},
     Model, Result,
 };
-use failure::format_err;
+use anyhow::anyhow;
 use minidom::{Element, Node};
 use proj::Proj;
 use relational_types::IdxSet;
@@ -188,7 +188,7 @@ impl<'a> OfferExporter<'a> {
         let route_points = self
             .route_points
             .get(route_id)
-            .ok_or_else(|| format_err!("Failed to generate RoutePoint for Route '{}'", route_id))?;
+            .ok_or_else(|| anyhow!("Failed to generate RoutePoint for Route '{}'", route_id))?;
         route_points
             .iter()
             .enumerate()
@@ -448,9 +448,10 @@ impl<'a> OfferExporter<'a> {
     }
 
     fn generate_points_on_route(&self, route_id: &'a str) -> Result<Element> {
-        let route_points = self.route_points.get(route_id).ok_or_else(|| {
-            format_err!("Failed to generate PointOnRoute for Route '{}'", route_id)
-        })?;
+        let route_points = self
+            .route_points
+            .get(route_id)
+            .ok_or_else(|| anyhow!("Failed to generate PointOnRoute for Route '{}'", route_id))?;
         let points_on_route =
             (1..=route_points.len()).map(|order| self.generate_point_on_route(route_id, order));
         let points_in_sequence = Element::builder("pointsInSequence")

--- a/src/netex_france/offer.rs
+++ b/src/netex_france/offer.rs
@@ -376,7 +376,7 @@ impl<'a> OfferExporter<'a> {
         let line_netex_mode = &self
             .line_modes
             .get(line_id.as_str())
-            .and_then(|line_netex_modes| NetexMode::calculate_highest_mode(line_netex_modes));
+            .and_then(NetexMode::calculate_highest_mode);
 
         let element_builder = Element::builder(ObjectType::ServiceJourney.to_string())
             .attr(
@@ -410,7 +410,7 @@ impl<'a> OfferExporter<'a> {
     fn export_timetabled_passing_times(stop_times: &'a [StopTime]) -> Vec<Element> {
         stop_times
             .iter()
-            .map(|stop_time| Self::export_timetabled_passing_time(stop_time))
+            .map(Self::export_timetabled_passing_time)
             .collect()
     }
 

--- a/src/netex_france/stops.rs
+++ b/src/netex_france/stops.rs
@@ -20,7 +20,7 @@ use crate::{
     objects::{Availability, Coord, Equipment, StopArea, StopLocation, StopPoint, StopType},
     Model, Result,
 };
-use failure::format_err;
+use anyhow::anyhow;
 use minidom::{Element, Node};
 use proj::Proj;
 use std::{
@@ -203,7 +203,7 @@ impl<'a> StopExporter<'a> {
             .get(stop_point.id.as_str())
             .ok_or_else(|| {
                 // Should never happen, a Stop Point always have some associated mode
-                format_err!("Unable to find modes for Stop Point '{}'", stop_point.id)
+                anyhow!("Unable to find modes for Stop Point '{}'", stop_point.id)
             })?;
         if netex_modes.len() > 1 {
             warn!(
@@ -214,9 +214,9 @@ impl<'a> StopExporter<'a> {
         let highest_netex_mode =
             NetexMode::calculate_highest_mode(netex_modes).ok_or_else(|| {
                 // Should never happen, a Stop Point always have at least one associated mode
-                format_err!(
+                anyhow!(
                     "Unable to resolve main NeTEx mode for Stop Point {}",
-                    stop_point.id
+                    stop_point.id,
                 )
             })?;
         let element_builder =
@@ -302,7 +302,7 @@ impl<'a> StopExporter<'a> {
             let highest_netex_mode =
                 NetexMode::calculate_highest_mode(&netex_modes).ok_or_else(|| {
                     // Should never happen, a Stop Area always have at least one associated mode
-                    format_err!(
+                    anyhow!(
                         "Unable to resolve main NeTEx mode for Stop Area {}",
                         stop_area.id
                     )

--- a/src/netex_france/transfers.rs
+++ b/src/netex_france/transfers.rs
@@ -17,7 +17,7 @@ use crate::{
     objects::Transfer,
     Model, Result,
 };
-use failure::format_err;
+use anyhow::anyhow;
 use minidom::{Element, Node};
 
 pub struct TransferExporter<'a> {
@@ -104,7 +104,7 @@ impl<'a> TransferExporter<'a> {
             .get(stop_point_id)
             .map(|stop_point| &stop_point.stop_area_id)
             .ok_or_else(|| {
-                format_err!(
+                anyhow!(
                     "StopPoint '{}' doesn't have a corresponding StopArea",
                     stop_point_id
                 )

--- a/src/netex_utils/mod.rs
+++ b/src/netex_utils/mod.rs
@@ -15,7 +15,7 @@
 //! Some utils to work with the NeTEx format, especially the frames.
 
 use crate::Result;
-use failure::{bail, format_err, Error};
+use anyhow::{anyhow, bail, Error};
 use minidom::Element;
 use minidom_ext::OnlyChildElementExt;
 use std::{
@@ -88,7 +88,7 @@ pub fn parse_frames_by_type(frames: &Element) -> Result<Frames<'_>> {
 pub fn get_only_frame<'a>(frames: &'a Frames<'a>, frame_type: FrameType) -> Result<&'a Element> {
     let frame = frames
         .get(&frame_type)
-        .ok_or_else(|| format_err!("Failed to find a '{}' frame in the Netex file", frame_type))?;
+        .ok_or_else(|| anyhow!("Failed to find a '{}' frame in the Netex file", frame_type))?;
     if frame.len() == 1 {
         Ok(frame[0])
     } else {
@@ -122,7 +122,7 @@ where
 {
     let values = element
         .try_only_child("KeyList")
-        .map_err(|e| format_err!("{}", e))?
+        .map_err(|e| anyhow!("{}", e))?
         .children()
         .filter(|key_value| match key_value.try_only_child("Key") {
             Ok(k) => k.text() == key,
@@ -131,7 +131,7 @@ where
         .map(|key_value| {
             key_value
                 .try_only_child("Value")
-                .map_err(|e| format_err!("{}", e))
+                .map_err(|e| anyhow!("{}", e))
         })
         .collect::<Result<Vec<_>>>()?;
     if values.len() != 1 {
@@ -144,7 +144,7 @@ where
     values[0]
         .text()
         .parse()
-        .map_err(|_| format_err!("Failed to get the value out of 'KeyList' for key '{}'", key))
+        .map_err(|_| anyhow!("Failed to get the value out of 'KeyList' for key '{}'", key))
 }
 
 #[cfg(test)]

--- a/src/ntfs/mod.rs
+++ b/src/ntfs/mod.rs
@@ -26,10 +26,10 @@ use crate::{
     utils::*,
     Result,
 };
+use anyhow::{anyhow, Context};
 use chrono::{DateTime, FixedOffset};
 use chrono_tz::Tz;
 use derivative::Derivative;
-use failure::ResultExt;
 use serde::{Deserialize, Serialize};
 use std::path;
 use tempfile::tempdir;
@@ -238,12 +238,12 @@ pub fn read<P: AsRef<path::Path>>(path: P) -> Result<Model> {
     let p = path.as_ref();
     if p.is_file() {
         // if it's a file, we consider it to be a zip (and an error will be returned if it is not)
-        Ok(from_zip(p).with_context(|_| format!("impossible to read zipped ntfs {:?}", p))?)
+        Ok(from_zip(p).with_context(|| format!("impossible to read zipped ntfs {:?}", p))?)
     } else if p.is_dir() {
         Ok(from_dir(p)
-            .with_context(|_| format!("impossible to read ntfs directory from {:?}", p))?)
+            .with_context(|| format!("impossible to read ntfs directory from {:?}", p))?)
     } else {
-        Err(failure::format_err!(
+        Err(anyhow!(
             "file {:?} is neither a file nor a directory, cannot read a ntfs from it",
             p
         ))
@@ -261,12 +261,12 @@ pub fn read_collections<P: AsRef<path::Path>>(path: P) -> Result<Collections> {
     if p.is_file() {
         // if it's a file, we consider it to be a zip (and an error will be returned if it is not)
         Ok(collections_from_zip(p)
-            .with_context(|_| format!("impossible to read zipped ntfs {:?}", p))?)
+            .with_context(|| format!("impossible to read zipped ntfs {:?}", p))?)
     } else if p.is_dir() {
         Ok(collections_from_dir(p)
-            .with_context(|_| format!("impossible to read ntfs directory from {:?}", p))?)
+            .with_context(|| format!("impossible to read ntfs directory from {:?}", p))?)
     } else {
-        Err(failure::format_err!(
+        Err(anyhow!(
             "file {:?} is neither a file nor a directory, cannot read a ntfs from it",
             p
         ))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,8 +16,8 @@ use crate::{
     objects::Date,
     read_utils::{read_objects, FileHandler},
 };
+use anyhow::Context;
 use chrono::NaiveDate;
-use failure::ResultExt;
 use rust_decimal::Decimal;
 use skip_error::skip_error_and_warn;
 use std::fs;
@@ -353,13 +353,13 @@ where
     info!("Writing {}", file);
     let path = path.join(file);
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for obj in collection.values() {
         wtr.serialize(obj)
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }
@@ -378,13 +378,13 @@ where
     info!("Writing {}", file);
     let path = path.join(file);
     let mut wtr =
-        csv::Writer::from_path(&path).with_context(|_| format!("Error reading {:?}", path))?;
+        csv::Writer::from_path(&path).with_context(|| format!("Error reading {:?}", path))?;
     for obj in collection.values() {
         wtr.serialize(obj)
-            .with_context(|_| format!("Error reading {:?}", path))?;
+            .with_context(|| format!("Error reading {:?}", path))?;
     }
     wtr.flush()
-        .with_context(|_| format!("Error reading {:?}", path))?;
+        .with_context(|| format!("Error reading {:?}", path))?;
 
     Ok(())
 }

--- a/tests/fixtures/netex_france/output/arrets.xml
+++ b/tests/fixtures/netex_france/output/arrets.xml
@@ -9,7 +9,7 @@
 					<Name>Gare de Lyon (RER)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<AccessibilityAssessment id="FR:AccessibilityAssessment:GDLR_0:" version="any">
@@ -32,7 +32,7 @@
 					<Name>Gare de Lyon (Metro)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<AccessibilityAssessment id="FR:AccessibilityAssessment:GDLM_1:" version="any">
@@ -55,7 +55,7 @@
 					<Name>Gare de Lyon (Bus)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>bus</TransportMode>
@@ -68,7 +68,7 @@
 					<Name>Nation (RER)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 						</Location>
 					</Centroid>
 					<AccessibilityAssessment id="FR:AccessibilityAssessment:NATR_0:" version="any">
@@ -91,7 +91,7 @@
 					<Name>Nation (Metro)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>metro</TransportMode>
@@ -104,7 +104,7 @@
 					<Name>Charles de Gaulle (RER)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>rail</TransportMode>
@@ -117,7 +117,7 @@
 					<Name>Charles de Gaulle (Metro)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>metro</TransportMode>
@@ -152,7 +152,7 @@
 					<Name>Montparnasse (Bus)</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>bus</TransportMode>
@@ -165,7 +165,7 @@
 					<Name>Gare de Lyon</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:GDL:">
@@ -181,7 +181,7 @@
 					<Name>Gare de Lyon</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:GDL:">
@@ -197,7 +197,7 @@
 					<Name>Gare de Lyon</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:GDL:">
@@ -215,7 +215,7 @@
 					<Name>Gare de Lyon</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+							<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 						</Location>
 					</Centroid>
 					<entrances>
@@ -223,7 +223,7 @@
 							<Name>Gate 1</Name>
 							<Centroid>
 								<Location>
-									<gml:pos srsName="EPSG:2154">654143.0840251445 6860726.200273179</gml:pos>
+									<gml:pos srsName="EPSG:2154">654143.0840251445 6860726.200273181</gml:pos>
 								</Location>
 							</Centroid>
 							<IsEntry>true</IsEntry>
@@ -233,7 +233,7 @@
 							<Name>Gate 2</Name>
 							<Centroid>
 								<Location>
-									<gml:pos srsName="EPSG:2154">654109.4203976962 6860534.540309813</gml:pos>
+									<gml:pos srsName="EPSG:2154">654109.4203976962 6860534.540309815</gml:pos>
 								</Location>
 							</Centroid>
 							<IsEntry>true</IsEntry>
@@ -247,7 +247,7 @@
 					<Name>Nation</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:NAT:">
@@ -263,7 +263,7 @@
 					<Name>Nation</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:NAT:">
@@ -279,7 +279,7 @@
 					<Name>Nation</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:NAT:">
@@ -295,7 +295,7 @@
 					<Name>Nation</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+							<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>rail</TransportMode>
@@ -305,7 +305,7 @@
 					<Name>Charles de Gaulle</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:CDG:">
@@ -321,7 +321,7 @@
 					<Name>Charles de Gaulle</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:CDG:">
@@ -337,7 +337,7 @@
 					<Name>Charles de Gaulle</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:CDG:">
@@ -353,7 +353,7 @@
 					<Name>Charles de Gaulle</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+							<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 						</Location>
 					</Centroid>
 					<entrances>
@@ -361,7 +361,7 @@
 							<Name>Gate A</Name>
 							<Centroid>
 								<Location>
-									<gml:pos srsName="EPSG:2154">648335.545974931 6863941.034152591</gml:pos>
+									<gml:pos srsName="EPSG:2154">648335.545974931 6863941.0341525925</gml:pos>
 								</Location>
 							</Centroid>
 							<IsEntry>true</IsEntry>
@@ -417,7 +417,7 @@
 					<Name>Châtelet</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">652172.9131210521 6862208.608972682</gml:pos>
+							<gml:pos srsName="EPSG:2154">652172.9131210521 6862208.608972684</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:CHA:">
@@ -433,7 +433,7 @@
 					<Name>Châtelet</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">652172.9131210521 6862208.608972682</gml:pos>
+							<gml:pos srsName="EPSG:2154">652172.9131210521 6862208.608972684</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>metro</TransportMode>
@@ -443,7 +443,7 @@
 					<Name>Montparnasse</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 						</Location>
 					</Centroid>
 					<ParentSiteRef ref="FR:StopPlace:MTP:">
@@ -459,7 +459,7 @@
 					<Name>Montparnasse</Name>
 					<Centroid>
 						<Location>
-							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+							<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 						</Location>
 					</Centroid>
 					<TransportMode>bus</TransportMode>

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_5cd0eea3662b0f30bd419b47ecb64840.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_5cd0eea3662b0f30bd419b47ecb64840.xml
@@ -57,17 +57,17 @@
 				</Route>
 				<RoutePoint id="FR:RoutePoint:RERA_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:RERA_2:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:RERA_3:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:RERA_4:" version="any">
@@ -82,17 +82,17 @@
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:RERA_Bus_R_2:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:RERA_Bus_R_3:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:RERA_Bus_R_4:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</RoutePoint>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:RERAF1:" version="any">
@@ -159,17 +159,17 @@
 				</ServiceJourneyPattern>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAF1_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAF1_2:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAF1_3:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAF1_5:" version="any">
@@ -184,17 +184,17 @@
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAB1_8:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAB1_13:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:RERAB1_21:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:RERAF1_1:" order="2" version="any">

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_MagicBus_23cdf50ee73fcba0d38beca2d8cc8c0e.xml
@@ -41,22 +41,22 @@
 				</Route>
 				<RoutePoint id="FR:RoutePoint:B42_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:B42_2:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:B42_R_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:B42_R_2:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</RoutePoint>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:B42F1:" version="any">
@@ -99,22 +99,22 @@
 				</ServiceJourneyPattern>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:B42F1_10:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:B42F1_20:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:B42B1_20:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.10406642</gml:pos>
+						<gml:pos srsName="EPSG:2154">650223.8079440364 6860484.104066422</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:B42B1_30:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:B42F1_10:" order="11" version="any">

--- a/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
+++ b/tests/fixtures/netex_france/output/reseau_TheGreatNetwork_1e97c33560621530a594ced114597ea1/offre_f31e1eef20f64733a18c538073e78396.xml
@@ -57,36 +57,36 @@
 				</Route>
 				<RoutePoint id="FR:RoutePoint:M1_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_2:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_3:" version="any">
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_4:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_R_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_R_2:" version="any">
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_R_3:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</RoutePoint>
 				<RoutePoint id="FR:RoutePoint:M1_R_4:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</RoutePoint>
 				<ServiceJourneyPattern id="FR:ServiceJourneyPattern:M1F1:" version="any">
@@ -153,36 +153,36 @@
 				</ServiceJourneyPattern>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_0:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_1:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_3:" version="any">
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1F1_4:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_6:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.8185047405</gml:pos>
+						<gml:pos srsName="EPSG:2154">648315.4028777299 6864001.818504742</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_7:" version="any">
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_8:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453682</gml:pos>
+						<gml:pos srsName="EPSG:2154">653983.726554971 6860704.890453683</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<ScheduledStopPoint id="FR:ScheduledStopPoint:M1B1_9:" version="any">
 					<Location>
-						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821124</gml:pos>
+						<gml:pos srsName="EPSG:2154">655712.2650990451 6861107.744821127</gml:pos>
 					</Location>
 				</ScheduledStopPoint>
 				<PassengerStopAssignment id="FR:PassengerStopAssignment:M1F1_0:" order="1" version="any">

--- a/tests/read_gtfs.rs
+++ b/tests/read_gtfs.rs
@@ -44,7 +44,7 @@ fn gtfs_with_config_reading() {
 
 #[test]
 #[should_panic(
-    expected = "ErrorMessage { msg: \"file \\\"tests/fixtures/i_m_not_here\\\" is neither a file nor a directory, cannot read a gtfs from it\" }"
+    expected = r#"file "tests/fixtures/i_m_not_here" is neither a file nor a directory, cannot read a gtfs from it"#
 )]
 fn unexistent_file() {
     // reading a file that does not exists will lead to an error
@@ -53,7 +53,7 @@ fn unexistent_file() {
 
 #[test]
 #[should_panic(
-    expected = "InvalidArchive(\"Could not find central directory end\")\n\nimpossible to read zipped gtfs \"tests/fixtures/gtfs/stops.txt\""
+    expected = "impossible to read zipped gtfs \"tests/fixtures/gtfs/stops.txt\"\n\nCaused by:\n    invalid Zip archive"
 )]
 fn file_not_a_gtfs() {
     // reading a file that is not either a directory with the gtfs files nor a zip archive will lead to an error
@@ -63,7 +63,7 @@ fn file_not_a_gtfs() {
 
 #[test]
 #[should_panic(
-    expected = "ErrorMessage { msg: \"calendar_dates.txt or calendar.txt not found\" }\n\nimpossible to read gtfs directory from \"tests/fixtures/netex_france\""
+    expected = "impossible to read gtfs directory from \"tests/fixtures/netex_france\"\n\nCaused by:\n    calendar_dates.txt or calendar.txt not found"
 )]
 fn directory_not_a_gtfs() {
     // reading a directory that does not contain the gtfs files will lead to an error

--- a/tests/read_ntfs.rs
+++ b/tests/read_ntfs.rs
@@ -99,7 +99,7 @@ fn zipped_minimal() {
 
 #[test]
 #[should_panic(
-    expected = "ErrorMessage { msg: \"file \\\"tests/fixtures/i_m_not_here\\\" is neither a file nor a directory, cannot read a ntfs from it\" }"
+    expected = "file \"tests/fixtures/i_m_not_here\" is neither a file nor a directory, cannot read a ntfs from it"
 )]
 fn unexistent_file() {
     // reading a file that does not exists will lead to an error
@@ -108,7 +108,7 @@ fn unexistent_file() {
 
 #[test]
 #[should_panic(
-    expected = "InvalidArchive(\"Could not find central directory end\")\n\nimpossible to read zipped ntfs \"tests/fixtures/ntfs/stops.txt\""
+    expected = "impossible to read zipped ntfs \"tests/fixtures/ntfs/stops.txt\"\n\nCaused by:\n    invalid Zip archive"
 )]
 fn file_not_a_ntfs() {
     // reading a file that is not either a directory with the ntfs files nor a zip archive will lead to an error
@@ -118,7 +118,7 @@ fn file_not_a_ntfs() {
 
 #[test]
 #[should_panic(
-    expected = "ErrorMessage { msg: \"file \\\"tests/fixtures/netex_france/contributors.txt\\\" not found\" }\n\nimpossible to read ntfs directory from \"tests/fixtures/netex_france\""
+    expected = "impossible to read ntfs directory from \"tests/fixtures/netex_france\"\n\nCaused by:\n    file \"tests/fixtures/netex_france/contributors.txt\" not found"
 )]
 fn directory_not_a_ntfs() {
     // reading a directory that does not contain the ntfs files will lead to an error


### PR DESCRIPTION
This takes parts of a larger effort to unify all dependencies in mimirsbrunn, a few notes here:

 - latest version of chrono appears to have a vulnerability: https://rustsec.org/advisories/RUSTSEC-2020-0159, I don't exactly understand why but it seems that it doesn't matter for a normal usage: https://github.com/chronotope/chrono/issues/499#issuecomment-940433677
 - minidom wasn't updated: https://github.com/CanalTP/transit_model/pull/746
 - replaced unmaintained failure with anyhow