### PR TITLE
fix: remove useless allocations with '.indexes()'

### DIFF
--- a/ntfs2gtfs/src/lib.rs
+++ b/ntfs2gtfs/src/lib.rs
@@ -18,8 +18,7 @@ use transit_model::{Model, Result};
 
 pub fn add_mode_to_line_code(model: Model) -> Result<Model> {
     let mut collections = model.into_collections();
-    let indexes: Vec<_> = collections.lines.iter().map(|(idx, _)| idx).collect();
-    for idx in indexes {
+    for idx in collections.lines.indexes() {
         let mut line = collections.lines.index_mut(idx);
         let mode = collections.commercial_modes.get(&line.commercial_mode_id);
         let code = match (line.code.clone(), mode) {

--- a/src/add_prefix.rs
+++ b/src/add_prefix.rs
@@ -134,8 +134,7 @@ where
     T: Id<T> + AddPrefix,
 {
     fn prefix(&mut self, prefix_conf: &PrefixConfiguration) {
-        let indexes: Vec<_> = self.iter().map(|(idx, _)| idx).collect();
-        for index in indexes {
+        for index in self.indexes() {
             self.index_mut(index).prefix(prefix_conf);
         }
     }

--- a/src/enhancers/enhance_pickup_dropoff.rs
+++ b/src/enhancers/enhance_pickup_dropoff.rs
@@ -136,14 +136,9 @@ pub fn enhance_pickup_dropoff(collections: &mut Collections) {
         other_block_id_vj.push((vj_idx, vj));
     }
 
-    let vj_idxs: Vec<Idx<VehicleJourney>> = collections
-        .vehicle_journeys
-        .iter()
-        .map(|(idx, _)| idx)
-        .collect();
     let is_route_point =
         |stop_time: &StopTime| stop_time.pickup_type == 3 || stop_time.drop_off_type == 3;
-    for vj_idx in vj_idxs {
+    for vj_idx in collections.vehicle_journeys.indexes() {
         let mut vj = collections.vehicle_journeys.index_mut(vj_idx);
 
         if !allowed_first_drop_off_vj.contains(&vj_idx) {

--- a/src/model.rs
+++ b/src/model.rs
@@ -121,12 +121,10 @@ pub struct Collections {
 impl Collections {
     /// Remove associated schedules with route points
     pub fn remove_route_points(&mut self) {
-        let vj_idxs: Vec<Idx<VehicleJourney>> =
-            self.vehicle_journeys.iter().map(|(idx, _)| idx).collect();
         let is_route_point = |stop_time: &StopTime| -> bool {
             stop_time.pickup_type == 3 || stop_time.drop_off_type == 3
         };
-        for vj_idx in vj_idxs {
+        for vj_idx in self.vehicle_journeys.indexes() {
             let mut vj = self.vehicle_journeys.index_mut(vj_idx);
             vj.stop_times.retain(|stop_time| !is_route_point(stop_time));
         }
@@ -754,9 +752,7 @@ impl Collections {
     /// If the vehicle didn't stop (point of route) on pickup,
     /// it must not stop on drop off and conversely
     pub fn pickup_drop_off_harmonisation(&mut self) {
-        let vj_idxs: Vec<Idx<VehicleJourney>> =
-            self.vehicle_journeys.iter().map(|(idx, _)| idx).collect();
-        for vj_idx in vj_idxs {
+        for vj_idx in self.vehicle_journeys.indexes() {
             let mut vj = self.vehicle_journeys.index_mut(vj_idx);
             for stop_time in vj
                 .stop_times


### PR DESCRIPTION
Some useless allocation now that we have `CollectionWithId::indexes()` which doesn't keep a reference on the `CollectionWithId`.